### PR TITLE
Adding docker build action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,4 +54,13 @@ jobs:
           --platform linux/amd64,linux/arm64,linux/arm/v7 \
           --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes:${{ env.RELEASE_TAG }}" \
           --output "type=registry" ./
+      - name: Run Docker buildx
+        run: |
+          docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache" \
+          --platform linux/amd64,linux/arm64,linux/arm/v7 \
+          --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes:latest" \
+          --output "type=registry" ./
+
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,57 @@
+name: Docker build on push
+env:
+  DOCKER_CLI_EXPERIMENTAL: enabled
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    name: Build and push Tribes image 
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    steps:
+      - name: Check out from Git
+        uses: actions/checkout@v2
+      - name: Test env
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Test print env
+        run: |
+          echo $RELEASE_TAG
+          echo ${{ env.RELEASE_TAG }}
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Setup Docker buildx action
+        uses: crazy-max/ghaction-docker-buildx@v1
+        id: buildx
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      - name: Show available buildx platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Test print env
+        run: |
+          echo $RELEASE_TAG
+          echo ${{ env.RELEASE_TAG }}
+      - name: Run Docker buildx
+        run: |
+          docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache" \
+          --platform linux/amd64,linux/arm64,linux/arm/v7 \
+          --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes:${{ env.RELEASE_TAG }}" \
+          --output "type=registry" ./
+


### PR DESCRIPTION
similar to relay it's probably good practice to have release tags for tribes so then maybe other people can run their own tribes servers aswell and can take the latest release.

This also helps with relays testing suite as we'll need the newest image to test changes with tribes properly

I mostly copied this one from relay but changed the tag

We do probably need to add those secret values and I do not have access to see or change them