### PR TITLE
New columns in bots table for url and secret and some other stuff

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -142,6 +142,30 @@ type Channel struct {
 	Deleted   bool       `json:"deleted"`
 }
 
+func (BotMigrateStruct) TableName() string {
+	return "bots"
+}
+
+type BotMigrateStruct struct {
+	UUID           string         `json:"uuid"`
+	OwnerPubKey    string         `json:"owner_pubkey"`
+	OwnerAlias     string         `json:"owner_alias"`
+	Name           string         `json:"name"`
+	UniqueName     string         `json:"unique_name"`
+	Description    string         `json:"description"`
+	Tags           pq.StringArray `json:"tags"`
+	Img            string         `json:"img"`
+	PricePerUse    int64          `json:"price_per_use"`
+	Created        *time.Time     `json:"created"`
+	Updated        *time.Time     `json:"updated"`
+	Unlisted       bool           `json:"unlisted"`
+	Deleted        bool           `json:"deleted"`
+	MemberCount    uint64         `json:"member_count"`
+	OwnerRouteHint string         `json:"owner_route_hint"`
+	Url            string         `json:"url"`
+	Secret         string         `json:"secret"`
+}
+
 /*
 GithubIssues
 stakwork/sphinx-relay/229: {


### PR DESCRIPTION
1) Made new column in bots table to store secret and url
2) Since the bot apis use a model without these fields they cannot be obtained from any of the existing apis.
3) Created a handler for creating/updating a new sphinx_ticket_bot from relay.
4) There can only be 1 such bot on the tribes server.