### PR TITLE
fix: typo getSphinx

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,5 +17,3 @@ Please delete options that are not relevant.
 - [ ] I have tested on Chrome and Firefox
 - [ ] I have tested on a mobile device
 - [ ] It has been deployed to people-test.sphinx.chat and tested by others
-- [ ] Do we need to implement analytics?
-- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

--- a/frontend/app/src/people/main/header.tsx
+++ b/frontend/app/src/people/main/header.tsx
@@ -291,7 +291,7 @@ export default function Header() {
                         }}
                     /> */}
 
-            <GetSphinxsBtn href={'https://sphinx.chat/'} target="_blank">Get Sphinxs</GetSphinxsBtn>
+            <GetSphinxsBtn href={'https://sphinx.chat/'} target="_blank">Get Sphinx</GetSphinxsBtn>
             {ui.meInfo ? (
               <LoggedInBtn
                 onClick={() => {


### PR DESCRIPTION
I merged this PR which had a typo
https://github.com/stakwork/sphinx-tribes/pull/318

this is just a quick change to fix that

## Issue ticket number and link
none

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [ ] It has been deployed to people-test.sphinx.chat and tested by others
