### PR TITLE
fix: font-family barlow

### DIFF
--- a/frontend/app/src/people/main/header.tsx
+++ b/frontend/app/src/people/main/header.tsx
@@ -524,6 +524,7 @@ const GetSphinxsBtn = styled.a`
   font-size: 14px;
   line-height: 19px;
   color: #ffffff;
+	font-family: Barlow;
 
   &:hover {
     background: #5881f8;


### PR DESCRIPTION
added font-family barlow to the "Get Sphinx" button

## Describe your changes
added font family barlow to Get Sphinx button
## Issue ticket number and link
none
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested on Chrome and Firefox
- [X] I have tested on a mobile device
- [ ] It has been deployed to people-test.sphinx.chat and tested by others
