### PR TITLE
[FIX] Modified wanteds api to not attach all the bounties for a ticket owner

### DIFF
--- a/db.go
+++ b/db.go
@@ -689,3 +689,30 @@ func (db database) updateLeaderBoard(uuid string, alias string, u map[string]int
 	db.db.Model(&LeaderBoard{}).Where("tribe_uuid = ? and alias = ?", uuid, alias).Updates(u)
 	return true
 }
+
+func (db database) countDevelopers() uint64 {
+	var count uint64
+	db.db.Model(&Person{}).Where("deleted = 'f' OR deleted is null").Count(&count)
+	return count
+}
+
+func (db database) countBounties() uint64 {
+	var count struct {
+		Sum uint64 `db:"sum"`
+	}
+	db.db.Raw(`Select sum(jsonb_array_length(extras -> 'wanted')) from people where 
+                   people.deleted = 'f' OR people.deleted is null`).Scan(&count)
+	return count.Sum
+}
+
+func (db database) getPeopleListShort(count uint32) *[]PersonInShort {
+	p := []PersonInShort{}
+	db.db.Raw(
+		`SELECT id, owner_pub_key, unique_name, img, uuid, owner_alias
+		FROM people
+		WHERE
+		(deleted = 'f' OR deleted is null)
+		ORDER BY random() 
+		LIMIT ?;`, count).Find(&p)
+	return &p
+}

--- a/routes.go
+++ b/routes.go
@@ -73,6 +73,8 @@ func NewRouter() *http.Server {
 		r.Get("/people", getListedPeople)
 		r.Get("/people/search", getPeopleBySearch)
 		r.Get("/people/posts", getListedPosts)
+		r.Get("/people/wanteds/header", getWantedsHeader)
+		r.Get("/people/short", getPeopleShortList)
 		r.Get("/people/wanteds", getListedWanteds)
 		r.Get("/people/offers", getListedOffers)
 		r.Get("/admin_pubkeys", getAdminPubkeys)
@@ -274,6 +276,27 @@ func getListedWanteds(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(people)
 	}
+}
+
+func getWantedsHeader(w http.ResponseWriter, r *http.Request) {
+	var ret struct {
+		DeveloperCount uint64           `json:"developer_count"`
+		BountiesCount  uint64           `json:"bounties_count"`
+		People         *[]PersonInShort `json:"people"`
+	}
+	ret.DeveloperCount = DB.countDevelopers()
+	ret.BountiesCount = DB.countBounties()
+	ret.People = DB.getPeopleListShort(3)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(ret)
+}
+
+func getPeopleShortList(w http.ResponseWriter, r *http.Request) {
+	var maxCount uint32 = 10000
+	people := DB.getPeopleListShort(maxCount)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(people)
 }
 func getListedOffers(w http.ResponseWriter, r *http.Request) {
 	people, err := DB.getListedOffers(r)

--- a/structs.go
+++ b/structs.go
@@ -95,6 +95,10 @@ func (Person) TableName() string {
 	return "people"
 }
 
+func (PersonInShort) TableName() string {
+	return "people"
+}
+
 // Person struct
 type Person struct {
 	ID               uint           `json:"id"`
@@ -117,6 +121,15 @@ type Person struct {
 	TwitterConfirmed bool           `json:"twitter_confirmed"`
 	GithubIssues     PropertyMap    `json:"github_issues", type: jsonb not null default '{}'::jsonb`
 	NewTicketTime    int64          `json:"new_ticket_time", gorm: "-:all"`
+}
+
+type PersonInShort struct {
+	ID          uint   `json:"id"`
+	Uuid        string `json:"uuid"`
+	OwnerPubKey string `json:"owner_pubkey"`
+	OwnerAlias  string `json:"owner_alias"`
+	UniqueName  string `json:"unique_name"`
+	Img         string `json:"img"`
 }
 
 // Github struct


### PR DESCRIPTION
## Describe your changes

Currently in the /wanteds api being used in the bounties page, each ticket has 2 objects: body, which contains the ticket information and person, which contains the owner information

But all the bounties belonging to the owner are also being attached in the person object, which is creating a massive redundancy of unnecessary data.

I've removed this 'wanteds' array for each owner


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

