### PR TITLE
fix: was not passing props for title and creator

### DIFF
--- a/frontend/app/src/people/widgetViews/summaries/wantedSummary.tsx
+++ b/frontend/app/src/people/widgetViews/summaries/wantedSummary.tsx
@@ -570,6 +570,8 @@ export default function WantedSummary(props: any) {
           creatorStep={creatorStep}
           isPaidStatusBadgeInfo={isPaidStatusBadgeInfo}
           isPaidStatusPopOver={isPaidStatusPopOver}
+          titleString={titleString}
+          nametag={nametag}
         />
       );
     }


### PR DESCRIPTION
## Describe your changes
We were not getting the title and creator icon when in the summary page passing these props fixes that
## Issue ticket number and link
none
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device (Only desktop view change but mobile still works)
- [ ] It has been deployed to people-test.sphinx.chat and tested by others
