### PR TITLE
fix/missing-white-color-at-bottom-tile

### DIFF
--- a/frontend/app/src/people/utils/paidBounty.tsx
+++ b/frontend/app/src/people/utils/paidBounty.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import { colors } from '../../config/colors';
 import BountyDescription from '../../bounties/bounty_description';
 import BountyPrice from '../../bounties/bounty_price';
 import BountyProfileView from '../../bounties/bounty_profile_view';
+import { colors } from '../../config/colors';
 
 const PaidBounty = (props) => {
   const color = colors['light'];
@@ -69,7 +69,7 @@ const BountyContainer = styled.div<PaidBountyProps>`
   flex-direction: row;
   width: 100%;
   font-family: Barlow;
-  height: 100% !important;
+  height: 160px !important;
   background: ${(p) => p.Bounty_Container_Background};
   border: 2px solid ${(p) => p.color.grayish.G950};
   border-radius: 10px;


### PR DESCRIPTION
## Describe your changes
white background should cover completely when hovering on paid bounties.

initial behaviour 

![Screenshot (16)](https://user-images.githubusercontent.com/44719946/228148468-8d84ccb4-cfbc-4f58-9eb6-c0a874c1e4b0.png)


new behaviour 
![Screenshot (15)](https://user-images.githubusercontent.com/44719946/228148549-9c04b9c3-aea5-4222-b9d0-71072e1b1e4e.png)

## Issue ticket number and link
#477 
## Type of change



Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [ ] It has been deployed to people-test.sphinx.chat and tested by others
