### PR TITLE
Feat/alt tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Authentication is handled by [sphinx-auth](https://github.com/stakwork/sphinx-au
 
 docker build --no-cache -t sphinx-tribes .
 
+docker tag sphinx-tribes sphinxlightning/sphinx-tribes:x
+
+docker push sphinxlightning/sphinx-tribes:x
+
 ### run against sphinx-stack
 
 To run tribes frontend locally, use these ports:

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -84,13 +84,12 @@ func PubKeyContext(next http.Handler) http.Handler {
 
 // VerifyTribeUUID takes base64 uuid and returns hex pubkey
 func VerifyTribeUUID(uuid string, checkTimestamp bool) (string, error) {
-	sigByes, err := base64.URLEncoding.DecodeString(uuid)
+
+	ts, timeBuf, sigBuf, err := ParseTokenString(uuid)
 	if err != nil {
 		return "", err
 	}
 
-	timeBuf := sigByes[:4] // unix timestamp is 4 bytes, or uint32
-	sigBuf := sigByes[4:]
 	pubkey, valid, err := VerifyAndExtract(timeBuf, sigBuf)
 	if err != nil || !valid || pubkey == "" {
 		return "", err
@@ -98,9 +97,8 @@ func VerifyTribeUUID(uuid string, checkTimestamp bool) (string, error) {
 
 	if checkTimestamp {
 		// 5 MINUTE MAX
-		ts := int64(binary.BigEndian.Uint32(timeBuf))
 		now := time.Now().Unix()
-		if ts < now-300 {
+		if int64(ts) < now-300 {
 			fmt.Println("TOO LATE!")
 			return "", errors.New("too late")
 		}
@@ -166,4 +164,40 @@ func EncodeToken(pubkey string) (string, error) {
 	}
 
 	return tokenString, nil
+}
+
+// tribe UUID is a base64 encoded string 69 bytes long
+// first 4 bytes is the timestamp
+// last 65 bytes is the sign
+
+// it can have two signature methods: signing the straight bytes
+// OR base64 encoding then utf8-string encoding than signing again.
+// the second method always prefixes the token with a "."
+// that way, signers that only support utf8 (CLN) can still make tokens
+
+func ParseTokenString(t string) (uint32, []byte, []byte, error) {
+	token := t
+	forceUtf8 := false
+	// this signifies its forced utf8 sig (for CLN SignMessage)
+	if strings.HasPrefix(t, ".") {
+		token = t[1:]
+		forceUtf8 = true
+	}
+	tBytes, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	if len(tBytes) < 5 {
+		return 0, nil, nil, errors.New("invalid signature (too short)")
+	}
+	sig := tBytes[4:]
+	timeBuf := tBytes[:4]
+	ts := binary.BigEndian.Uint32(timeBuf)
+	if forceUtf8 {
+		ts64 := base64.URLEncoding.EncodeToString(timeBuf)
+		return ts, []byte(ts64), sig, nil
+	} else {
+		timeBuf := tBytes[:4]
+		return ts, timeBuf, sig, nil
+	}
 }

--- a/db/store.go
+++ b/db/store.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/patrickmn/go-cache"
 	"github.com/stakwork/sphinx-tribes/auth"
-	"golang.org/x/crypto/blake2b"
 )
 
 type StoreData struct {
@@ -102,7 +101,8 @@ func (s StoreData) GetInvoiceCount(key string) (uint, error) {
 
 func Ask(w http.ResponseWriter, r *http.Request) {
 	ts := strconv.Itoa(int(time.Now().Unix()))
-	h := blake2b.Sum256([]byte(ts))
+	h := []byte(ts)
+	// h := blake2b.Sum256([]byte(ts))
 	challenge := base64.URLEncoding.EncodeToString(h[:])
 
 	Store.SetCache(challenge, ts)


### PR DESCRIPTION
## Describe your changes

Allows for tokens (tribe uuids) to be signed in a different way (utf8 only... timestamps are endcoded to base64 first, and the token is prefixed with a ".")


