### PR TITLE
better check if a token is a jwt

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -45,7 +45,7 @@ func PubKeyContext(next http.Handler) http.Handler {
 			return
 		}
 
-		isJwt := strings.Contains(token, ".")
+		isJwt := strings.Contains(token, ".") && !strings.HasPrefix(token, ".")
 
 		if isJwt {
 			claims, err := DecodeToken(token)


### PR DESCRIPTION
## Describe your changes

The `PubKeyContext` func handles both JWTs and signed timestamps from relay. But now there is a new signed timestamp format that begins with a "."

So this logic `strings.Contains(token, ".")` was mistakenly thinking that a signed timestamp was a JWT

Replaces it with `strings.Contains(token, ".") && !strings.HasPrefix(token, ".")`
