### PR TITLE
fixed relay people duplicate

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -221,7 +221,7 @@ func (db database) CreateOrEditPerson(m Person) (Person, error) {
 		db.db.Model(&m).Where("id = ?", m.ID).UpdateColumns(&updatePriceToMeet)
 	}
 
-	if db.db.Model(&m).Where("id = ?", m.ID).Updates(&m).RowsAffected == 0 {
+	if db.db.Model(&m).Where("owner_pub_key = ?", m.OwnerPubKey).Updates(&m).RowsAffected == 0 {
 		db.db.Create(&m)
 	}
 

--- a/frontend/app/src/pages/index.tsx
+++ b/frontend/app/src/pages/index.tsx
@@ -26,7 +26,9 @@ const modeDispatchPages: Record<AppMode, () => React.ReactElement> = {
         <Route path="/b/">
           <BotsBody />
         </Route>
-        <Route path="/p/" render={() => <People />} />
+        <Route path="/p/">
+          <People />
+        </Route>
         <Route path="/tickets/">
           <TicketsPage />
         </Route>

--- a/frontend/app/src/people/main/Header.tsx
+++ b/frontend/app/src/people/main/Header.tsx
@@ -324,8 +324,12 @@ function Header() {
   }, []);
 
   function goToEditSelf() {
+    const path = location.pathname;
     if (ui.meInfo?.id) {
-      history.push(`/p/${ui.meInfo.owner_pubkey}`);
+      history.push(`/p/${ui.meInfo.owner_pubkey}/`);
+      if (path.includes('/p')) {
+        window.location.reload();
+      }
       ui.setSelectedPerson(ui.meInfo.id);
       ui.setSelectingPerson(ui.meInfo.id);
     }


### PR DESCRIPTION
## Describe your changes

This PR fixes the  Relay duplication by using the public key as a check, and also it forces the reloading of the page when the user clicks on a user icon from the people page.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device