### PR TITLE
fix: remove hardcoded link in twitter sharing

### DIFF
--- a/frontend/app/src/people/widgetViews/summaries/wantedSummaries/lib.ts
+++ b/frontend/app/src/people/widgetViews/summaries/wantedSummaries/lib.ts
@@ -11,7 +11,12 @@ export const getTwitterLink = ({ title, issueCreated, ownerPubkey, labels }: Pro
     owner_id: ownerPubkey,
     created: issueCreated
   };
-  const bountyUrl = new URL('https://community.sphinx.chat/tickets');
+  const origin = window.location.origin.includes('localhost')
+    ? 'https://community.sphinx.chat'
+    : window.location.origin;
+
+    const bountyUrl = new URL('/tickets', origin);
+
 
   for (const key in bountyParams) {
     bountyUrl.searchParams.append(key, bountyParams[key]);


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
closes #687

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
