### PR TITLE
fix: added memo text in keysend payment

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -56,10 +56,11 @@ func BuildSearchQuery(key string, term string) (string, string) {
 
 func BuildKeysendBodyData(amount uint, receiver_pubkey string, route_hint string) string {
 	var bodyData string
+	memoText := "memotext added for notification"
 	if route_hint != "" {
-		bodyData = fmt.Sprintf(`{"amount": %d, "destination_key": "%s", "route_hint": "%s"}`, amount, receiver_pubkey, route_hint)
+		bodyData = fmt.Sprintf(`{"amount": %d, "destination_key": "%s", "route_hint": "%s", "text": "%s"}`, amount, receiver_pubkey, route_hint, memoText)
 	} else {
-		bodyData = fmt.Sprintf(`{"amount": %d, "destination_key": "%s"}`, amount, receiver_pubkey)
+		bodyData = fmt.Sprintf(`{"amount": %d, "destination_key": "%s", "text": "%s"}`, amount, receiver_pubkey, memoText)
 	}
 
 	return bodyData


### PR DESCRIPTION
## Describe your changes

For some reason sphinx-relay requires memo text in order to send a notfication from a keysend payment so I added that in helpers/utils.go

## Type of change
bug fix
