### PR TITLE
fix: option to open in a new tab is not displayed in the menu

### DIFF
--- a/frontend/app/src/pages/people/tabs/Wanted.tsx
+++ b/frontend/app/src/pages/people/tabs/Wanted.tsx
@@ -22,7 +22,7 @@ const Container = styled.div`
 interface PanelProps {
   isMobile: boolean;
 }
-const Panel = styled.div<PanelProps>`
+const Panel = styled.a<PanelProps>`
   position: relative;
   overflow: hidden;
   cursor: pointer;
@@ -33,6 +33,10 @@ const Panel = styled.div<PanelProps>`
   padding: 20px;
   box-shadow: ${(p: any) => (p.isMobile ? 'none' : '0px 0px 6px rgb(0 0 0 / 7%)')};
   border-bottom: ${(p: any) => (p.isMobile ? '2px solid #EBEDEF' : 'none')};
+
+  &:hover {
+    text-decoration: none !important;  
+  }
 `;
 
 export const Wanted = observer(() => {
@@ -106,6 +110,7 @@ export const Wanted = observer(() => {
         if (w.body.owner_id === person?.owner_pubkey) {
           return (
             <Panel
+              href={`${url}/${w.body.id}/${i}`}
               key={w.body.id}
               isMobile={false}
               onClick={() => {

--- a/frontend/app/src/people/widgetViews/OrganizationView.tsx
+++ b/frontend/app/src/people/widgetViews/OrganizationView.tsx
@@ -34,7 +34,7 @@ const Container = styled.div`
   }
 `;
 
-const OrganizationWrap = styled.div`
+const OrganizationWrap = styled.a`
   display: flex;
   flex-direction: row;
   width: 100%;
@@ -51,6 +51,10 @@ const OrganizationWrap = styled.div`
   }
   @media only screen and (max-width: 500px) {
     padding: 0px;
+  }
+
+  &:hover {
+    text-decoration: none !important;  
   }
 `;
 
@@ -192,7 +196,7 @@ const Organizations = (props: { person: Person }) => {
   const orgUi = (org: any, key: number) => {
     const btnDisabled = (!org.bounty_count && org.bount_count !== 0) || !org.uuid;
     return (
-      <OrganizationWrap key={key}>
+      <OrganizationWrap key={key} href={`/org/bounties/${org.uuid}`}>
         <OrganizationData>
           <OrganizationImg src={org.img || avatarIcon} />
           <OrganizationBudget org={org} user_pubkey={user_pubkey ?? ''} />

--- a/frontend/app/src/people/widgetViews/UserTicketsView.tsx
+++ b/frontend/app/src/people/widgetViews/UserTicketsView.tsx
@@ -24,7 +24,7 @@ const Container = styled.div`
 interface PanelProps {
   isMobile: boolean;
 }
-const Panel = styled.div<PanelProps>`
+const Panel = styled.a<PanelProps>`
   position: relative;
   overflow: hidden;
   cursor: pointer;
@@ -35,6 +35,10 @@ const Panel = styled.div<PanelProps>`
   padding: 20px;
   box-shadow: ${(p: any) => (p.isMobile ? 'none' : '0px 0px 6px rgb(0 0 0 / 7%)')};
   border-bottom: ${(p: any) => (p.isMobile ? '2px solid #EBEDEF' : 'none')};
+
+  &:hover {
+    text-decoration: none !important;  
+  }
 `;
 
 const UserTickets = () => {
@@ -106,7 +110,8 @@ const UserTickets = () => {
         const body = { ...item.body };
         // if this person has entries for this widget
         return (
-          <Panel isMobile={isMobile} key={i + body?.created}>
+          <Panel href={`${url}/${body.id}/${i}`} isMobile={isMobile} key={i + body?.created}>
+            container
             <WantedView
               colors={color}
               showName

--- a/frontend/app/src/people/widgetViews/WidgetSwitchViewer.tsx
+++ b/frontend/app/src/people/widgetViews/WidgetSwitchViewer.tsx
@@ -20,7 +20,7 @@ interface PanelProps {
   isAssignee?: boolean;
 }
 
-const Panel = styled.div<PanelProps>`
+const Panel = styled.a<PanelProps>`
   margin-top: 5px;
   background: ${(p: any) => p.color && p.color.pureWhite};
   color: ${(p: any) => p.color && p.color.pureBlack};
@@ -29,7 +29,8 @@ const Panel = styled.div<PanelProps>`
   :hover {
     box-shadow: ${(p: any) =>
       p.isAssignee ? `0px 1px 6px ${p.color.black100}` : 'none'} !important;
-  }
+    text-decoration: none !important;  
+}
   :active {
     box-shadow: none !important;
   }
@@ -167,6 +168,7 @@ function WidgetSwitchViewer(props: any) {
         // if this person has entries for this widget
         return (
           <Panel
+            href={`/bounty/${body.id}`}
             color={color}
             isMobile={isMobile}
             key={person?.owner_pubkey + i + body?.created}


### PR DESCRIPTION
### Describe your change

The option to open a new tab is now displayed in the menu for the home page, profile: bounties, profile: assigned, and org page

### Closes: 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Preview #942

https://www.loom.com/share/789ccee0f52d47e3beda47a399f1a662?sid=38261909-bbf9-4c92-9cbc-abf77861fe4b

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend