### PR TITLE
fix(#1137): Display created bounty after successful bounty creation

### DIFF
--- a/frontend/app/src/people/widgetViews/postBounty/PostModal.tsx
+++ b/frontend/app/src/people/widgetViews/postBounty/PostModal.tsx
@@ -40,7 +40,7 @@ export const PostModal: FC<PostModalProps> = observer(
       */
       const number = await getBountyData();
       history.push(`/bounty/${number}`);
-      await window.location.reload();
+      
     };
 
     const closeHandler = () => {

--- a/frontend/app/src/people/widgetViews/postBounty/PostModal.tsx
+++ b/frontend/app/src/people/widgetViews/postBounty/PostModal.tsx
@@ -40,7 +40,6 @@ export const PostModal: FC<PostModalProps> = observer(
       */
       const number = await getBountyData();
       history.push(`/bounty/${number}`);
-      
     };
 
     const closeHandler = () => {

--- a/frontend/app/src/people/widgetViews/postBounty/PostModal.tsx
+++ b/frontend/app/src/people/widgetViews/postBounty/PostModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import { colors } from '../../../config/colors';
@@ -29,11 +29,17 @@ export const PostModal: FC<PostModalProps> = observer(
     const canEdit = id === ui.meInfo?.id;
     const config = widgetConfigs[widget];
 
+    const getBountyData = useCallback(async () => {
+      const response = await main.getPeopleBounties();
+      return response[0].body.id;
+    }, [main]);
+
     const ReCallBounties = async () => {
       /*
       TODO : after getting the better way to reload the bounty, this code will be removed.
       */
-      history.push('/bounties');
+      const number = await getBountyData();
+      history.push(`/bounty/${number}`);
       await window.location.reload();
     };
 


### PR DESCRIPTION
With This pull request changes made are:
Now when you post a bounty you are redirected to the created bounty page as required by the issue #1137

The fix : get the current bounty index from api and use the data to redirect to created bounty page

video 


https://github.com/stakwork/sphinx-tribes/assets/89837102/07093217-cbfc-4450-b3a1-74b2fcc8846f


This has been Tested on Chrome and Firefox
fixes #1137