### PR TITLE
fix(#1193):fixed icon displacement on window scaling

### DIFF
--- a/frontend/app/src/components/common/ImageButton.tsx
+++ b/frontend/app/src/components/common/ImageButton.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 interface ButtonContainerProps {
   topMargin?: string;
   disabled?: boolean;
+  paddingLeft?: string;
+  paddingRight?: string;
 }
 
 const ButtonContainer = styled.div<ButtonContainerProps>`
@@ -14,10 +16,8 @@ const ButtonContainer = styled.div<ButtonContainerProps>`
   display: flex;
   align-items: center;
   justify-content: center;
-
   pointer-events: ${({ disabled }: ButtonContainerProps) => (disabled ? 'none' : 'all')};
   cursor: pointer;
-
   opacity: ${({ disabled }: ButtonContainerProps) => (disabled ? 0.8 : 1)};
   margin-top: ${(p: any) => p?.topMargin};
   background: #ffffff;
@@ -25,7 +25,7 @@ const ButtonContainer = styled.div<ButtonContainerProps>`
   border-radius: 30px;
   user-select: none;
   .ImageContainer {
-    position: absolute;
+    /* position: absolute; */
     min-height: 48px;
     min-width: 48px;
     right: 37px;
@@ -34,10 +34,11 @@ const ButtonContainer = styled.div<ButtonContainerProps>`
     justify-content: center;
   }
   .leadingImageContainer {
-    position: absolute;
-    min-height: 48px;
-    min-width: 48px;
-    left: 300px;
+    /* position: absolute; */
+    /* min-height: 48px;
+    min-width: 48px; */
+    padding-left: 20px;
+    padding-right: 15px;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/frontend/app/src/components/common/ImageButton.tsx
+++ b/frontend/app/src/components/common/ImageButton.tsx
@@ -25,7 +25,6 @@ const ButtonContainer = styled.div<ButtonContainerProps>`
   border-radius: 30px;
   user-select: none;
   .ImageContainer {
-    /* position: absolute; */
     min-height: 48px;
     min-width: 48px;
     right: 37px;
@@ -34,9 +33,6 @@ const ButtonContainer = styled.div<ButtonContainerProps>`
     justify-content: center;
   }
   .leadingImageContainer {
-    /* position: absolute; */
-    /* min-height: 48px;
-    min-width: 48px; */
     padding-left: 20px;
     padding-right: 15px;
     display: flex;

--- a/frontend/app/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
+++ b/frontend/app/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
@@ -533,6 +533,9 @@ function MobileView(props: CodingBountiesProps) {
                               left: 320
                             }}
                             buttonAction={props?.editAction}
+                            buttonTextStyle={{
+                              paddingRight: '50px'
+                            }}
                           />
                           <ImageButton
                             buttonText={!props.deletingState ? 'Delete' : 'Deleting'}
@@ -546,6 +549,9 @@ function MobileView(props: CodingBountiesProps) {
                             }}
                             disabled={!props?.deleteAction}
                             buttonAction={props?.deleteAction}
+                            buttonTextStyle={{
+                              paddingRight: '45px'
+                            }}
                           />
                         </div>
                       )}
@@ -658,7 +664,8 @@ function MobileView(props: CodingBountiesProps) {
                           }}
                           buttonTextStyle={{
                             color: color.grayish.G50,
-                            width: '114px'
+                            width: '114px',
+                            paddingLeft: '20px'
                           }}
                           endImageSrc={'/static/addIcon.svg'}
                           endingImageContainerStyle={{


### PR DESCRIPTION
Fixed the displacement of icons with this PR fixes #1193 

cause: use of position:absolute in the styles
fix: removing position absolute and using css padding as props to position icons and text correctly

video

https://github.com/stakwork/sphinx-tribes/assets/89837102/222adfdb-b097-49e4-9304-457ae348f5fa

tested on Chrome and Firefox
