### PR TITLE
Fixed: Fix Issue with Organization Page Redirection on Bounty Home Page

### DIFF
--- a/frontend/app/src/bounties/BountyDescription.tsx
+++ b/frontend/app/src/bounties/BountyDescription.tsx
@@ -2,7 +2,6 @@ import { EuiText } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { isString } from 'lodash';
-import { Link } from 'react-router-dom';
 import { OrganizationText, OrganizationWrap } from '../people/utils/style';
 import { colors } from '../config/colors';
 import { LanguageObject } from '../people/utils/languageLabelStyle';
@@ -144,6 +143,13 @@ const BountyDescription = (props: BountiesDescriptionProps) => {
     setDataValue(res);
   }, [props.codingLanguage]);
 
+  const handleOrgPage = (event:any, orgUuid:any) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const orgPageUrl = `/org/bounties/${orgUuid}`;
+    window.open(orgPageUrl, '_blank');
+  };
+
   return (
     <>
       <BountyDescriptionContainer style={{ ...props.style }}>
@@ -164,29 +170,23 @@ const BountyDescription = (props: BountiesDescriptionProps) => {
             />
           </div>
           {props.org_uuid && props.name && (
-            <Link
-              onClick={(e: any) => {
-                e.stopPropagation();
-              }}
-              to={`/org/bounties/${props.org_uuid}`}
-              target="_blank"
-            >
-              <OrganizationWrap>
-                <Img
-                  title={`${props.name} logo`}
-                  src={props.org_img || '/static/person_placeholder.png'}
-                />
-                <OrganizationText>{props.name}</OrganizationText>
-                <img
-                  className="buttonImage"
-                  src={'/static/github_ticket.svg'}
-                  alt={'github_ticket'}
-                  height={'10px'}
-                  width={'10px'}
-                  style={{ transform: 'translateY(1px)' }}
-                />
-              </OrganizationWrap>
-            </Link>
+              <div onClick={(event: any) => handleOrgPage(event, props.org_uuid)}>
+                <OrganizationWrap>
+                  <Img
+                      title={`${props.name} logo`}
+                      src={props.org_img || '/static/person_placeholder.png'}
+                  />
+                  <OrganizationText>{props.name}</OrganizationText>
+                  <img
+                      className="buttonImage"
+                      src={'/static/github_ticket.svg'}
+                      alt={'github_ticket'}
+                      height={'10px'}
+                      width={'10px'}
+                      style={{transform: 'translateY(1px)'}}
+                  />
+                </OrganizationWrap>
+              </div>
           )}
         </Header>
         <Description isPaid={props?.isPaid} color={color}>


### PR DESCRIPTION
### Problem:
when users click on an organization `(org)` link within the home page, they are redirected to a bounty-specific page in the same tab, which is not the intended behavior. Users expect to navigate to the organization's specific page with its bounties, and it should open in a new tab without redirecting the current page.

## Issue ticket number and link:
- **Ticket Number:** [ 1122 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes/issues/1122 ]

### Solution:
Implemented a new function `handleOrgPage` to handle the redirection. This function prevents the default action and propagation of the click event on the organization links, and then uses `window.open` to open the organization's specific bounties page in a new tab.

### Changes:
 - The `handleOrgPage` function now prevents default behavior and stops event propagation.
 - The function to include `event.preventDefault()` and `event.stopPropagation()` to prevent the default link behavior and stop event propagation.
 - It constructs the URL for the organization's page based on the organization's UUID.
 - The organization page is then opened in a new browser tab `(_blank)` when an organization is clicked.
 - This logic is implemented in a `<div>` element that wraps the `<OrganizationWrap>` component, ensuring that the entire organization element is clickable and leads to the correct page.

### Evidence:
Included is a video demonstration showing the corrected behavior. Now, when clicking on an organization's name on the bounty home page, a new tab opens with the organization's specific bounties, as intended.
**Video Link:** [ [https://www.loom.com/share/6504cfe7144e469c90bfb1cb03fc334c](url) ]

### Testing:
- Navigate to the home page.
- Click on any organization link.
- Verify that the organization's specific bounties page opens in a new tab.
- Ensure the original page remains intact and does not redirect or refresh.
- Manual testing across different devices and screen resolutions.
- Verified that no other functionalities are impacted by this change.

### Notes:
Please review the changes and merge this PR if everything is in order. This fix is essential for the upcoming release, and I look forward to any feedback you might have.