### PR TITLE
Fix Bounty changing owner Pubkey when updating

### DIFF
--- a/frontend/app/src/people/main/FocusView.tsx
+++ b/frontend/app/src/people/main/FocusView.tsx
@@ -235,7 +235,17 @@ function FocusedView(props: FocusViewProps) {
         newBody.title = body.title;
       }
       newBody.one_sentence_summary = '';
-      newBody.owner_id = info.pubkey;
+
+      if (!newBody.id && !newBody.owner_id) {
+        newBody.owner_id = info.pubkey;
+      }
+
+      // For editing a bounty, get the pubkey of the bounty creator
+      const bounty = await main.getBountyById(Number(newBody.id));
+      if (newBody.id && bounty.length) {
+        const b = bounty[0];
+        newBody.owner_id = b.body.owner_id;
+      }
 
       await main.saveBounty(newBody);
 


### PR DESCRIPTION
## Describe your changes

This PR fixes the bug of changing a bounty creator Pubkey when giving a manage bounty role.

## Issue ticket number and link

Closes #1199 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device