### PR TITLE
fix(no-badge): Fixed Badge Display Next to Filter on Mobile View

### DIFF
--- a/frontend/app/src/people/widgetViews/BountyHeader.tsx
+++ b/frontend/app/src/people/widgetViews/BountyHeader.tsx
@@ -614,6 +614,11 @@ const BountyHeader = ({
                 </PopOverRightBox>
               </div>
             </EuiPopover>
+            {filterCountNumber > 0 && (
+              <FilterCount color={color}>
+                <EuiText className="filterCountText">{filterCountNumber}</EuiText>
+              </FilterCount>
+            )}
           </LargeActionContainer>
           <ShortActionContainer>
             <PostBounty widget={selectedWidget} />

--- a/frontend/app/src/people/widgetViews/BountyHeader.tsx
+++ b/frontend/app/src/people/widgetViews/BountyHeader.tsx
@@ -177,6 +177,28 @@ const FilterCount = styled.div<styledProps>`
   }
 `;
 
+const MobileFilterCount = styled.div<styledProps>`
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  margin-left: -8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: -5px;
+  background: ${(p: any) => p?.color && p.color.blue1};
+  .filterCountText {
+    font-family: 'Barlow';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    color: ${(p: any) => p.color && p.color.pureWhite};
+  }
+`;
+
 const EuiPopOverCheckboxLeft = styled.div<styledProps>`
   width: 147px;
   height: 312px;
@@ -615,9 +637,9 @@ const BountyHeader = ({
               </div>
             </EuiPopover>
             {filterCountNumber > 0 && (
-              <FilterCount color={color}>
+              <MobileFilterCount color={color}>
                 <EuiText className="filterCountText">{filterCountNumber}</EuiText>
-              </FilterCount>
+              </MobileFilterCount>
             )}
           </LargeActionContainer>
           <ShortActionContainer>


### PR DESCRIPTION
### Problem:
The `filter count badge`, which indicates the presence of active filters, is currently not displayed in the `mobile version` of our application. This inconsistency between the desktop and mobile versions can lead to a confusing user experience.

### Expected Behavior:
The `filter count badge` should be visible next to the filter button on both `desktop` and `mobile` layouts. It should accurately display the number of active filters selected by the user.

## Issue ticket number and link:
- **Ticket Number:** [ 1206 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes/issues/1206 ]

### Solution:
Implemented a new styled component `MobileFilterCount` that is responsible for displaying the filter count badge specifically in the mobile view. This component is similar to the existing `FilterCount` but is optimized for smaller screens and mobile usage.

### Changes:
 - Created a `MobileFilterCount` styled component with adjusted size and positioning for mobile screens.
 - Included the `MobileFilterCount` component within the `BountyHeaderMobile` component to display the filter count badge.
 - Conditional rendering added to display the badge only when there is at least one active filter (`filterCountNumber > 0`).
 - Ensured the `filterCountNumber` state is utilized to update and display the filter count on both desktop and mobile layouts.

### Evidence:
 Please see the attached image as evidence.
- Image#1: [Link](https://drive.google.com/file/d/1ffw6Wa4PopTQLGywOj6NOV_zh12E1N4N/view?usp=sharing)
- Image#2: [Link](https://drive.google.com/file/d/1QnfEs2GgB8Lxa2CnxBLUoDKElExlIYS9/view?usp=sharing)
- Image#3: [Link](https://drive.google.com/file/d/1IbVk0ZJ2EjXmIReQKFjC8r1wOmT4Jm0w/view?usp=sharing)
- Image#4: [Link](https://drive.google.com/file/d/11KHkYrHtebFWNFSTHXaEkXCOuZumhG_H/view?usp=sharing)

### Testing:
- **Manual Testing:** Conducted on various devices and screen sizes to ensure the badge appears and updates correctly.
- Verified that no other functionalities are impacted by this change.
- Conducted performance testing to ensure no significant impact on mobile rendering times.

