### PR TITLE
fix(#1245):fix correct label

### DIFF
--- a/frontend/app/src/pages/superadmin/tableComponent/index.tsx
+++ b/frontend/app/src/pages/superadmin/tableComponent/index.tsx
@@ -265,7 +265,7 @@ export const MyTable = ({ bounties, startDate, endDate }: TableProps) => {
             {currentPageData()?.map((bounty: any) => {
               const bounty_status =
                 bounty?.paid && bounty.assignee
-                  ? 'completed'
+                  ? 'paid'
                   : bounty.assignee && !bounty.paid
                   ? 'assigned'
                   : 'open';


### PR DESCRIPTION
With This PR admin page now shows the correct label for the paid issue previously it was shown completed

screenshot
![1F371B35-EF06-4B6B-B499-44B4482EC86A_4_5005_c](https://github.com/stakwork/sphinx-tribes/assets/89837102/f8636e47-7925-4b64-a864-47697bf7c926)

Tested On Chrome and firefox

fix in code block
<img width="413" alt="Screenshot 2024-01-04 at 7 08 35 PM" src="https://github.com/stakwork/sphinx-tribes/assets/89837102/e3d97b13-4f34-444b-98f0-fcb36fc01369">
Closes #1245 
