### PR TITLE
fix(bounty-twice): Fixed Duplicate PopUp Issue When Viewing Bounty From Profile

### DIFF
--- a/frontend/app/src/pages/people/tabs/Wanted.tsx
+++ b/frontend/app/src/pages/people/tabs/Wanted.tsx
@@ -113,7 +113,8 @@ export const Wanted = observer(() => {
               href={`${url}/${w.body.id}/${i}`}
               key={w.body.id}
               isMobile={false}
-              onClick={() => {
+              onClick={(e: any) => {
+                e.preventDefault();
                 ui.setBountyPerson(person?.id);
                 history.push({
                   pathname: `${url}/${w.body.id}/${i}`

--- a/frontend/app/src/people/widgetViews/UserTicketsView.tsx
+++ b/frontend/app/src/people/widgetViews/UserTicketsView.tsx
@@ -122,7 +122,7 @@ const UserTickets = () => {
               colors={color}
               showName
               onPanelClick={(e: any) => {
-                  e.preventDefault();
+                e.preventDefault();
                 onPanelClick(body.id, i);
                 ui.setBountyPerson(person?.id);
                 setBountyOwner(person);

--- a/frontend/app/src/people/widgetViews/UserTicketsView.tsx
+++ b/frontend/app/src/people/widgetViews/UserTicketsView.tsx
@@ -121,7 +121,8 @@ const UserTickets = () => {
             <WantedView
               colors={color}
               showName
-              onPanelClick={() => {
+              onPanelClick={(e: any) => {
+                  e.preventDefault();
                 onPanelClick(body.id, i);
                 ui.setBountyPerson(person?.id);
                 setBountyOwner(person);


### PR DESCRIPTION
### Problem:
When viewing a bounty in the profile (both under `Created` and `Assigned` sections), the bounty detail page is incorrectly displayed twice. This appears to be a result of the default behavior of the anchor tags in the `Panel` components, causing duplicate navigation actions.

### Expected Behavior:
The expected behavior is that when a user clicks on a bounty in their profile, the bounty detail page should appear only once, providing a clean and user-friendly experience.

## Issue ticket number and link:
- **Ticket Number:** [ 1254 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes/issues/1254 ]

### Solution:
The issue was resolved by preventing the default action of the anchor tags in the `Panel` components within both `UserTicketView.tsx` and `Wanted.tsx` files. This was achieved by adding `e.preventDefault()` in the `onClick` event handlers, thus stopping the default navigation and allowing for the custom routing logic to execute correctly.

### Changes:
 - In `UserTicketView.tsx`, modified the `onPanelClick` function to include `e.preventDefault()` to stop the anchor tag from triggering a page load.
 - In `Wanted.tsx`, added `e.preventDefault()` in the `onClick` handler of the Panel component to prevent default navigation and instead use the `history.push()` method for navigation.

### Evidence:
 Please see the attached video as evidence.
 - [Demo](https://www.loom.com/share/de58d3645e0b4cbcbfc14226f4e9ba92)

### Testing:
- Clicked on various bounties in both `Created` and `Assigned` sections of the profile to ensure that the detail page opens correctly.
- Verified that the issue of the detail page appearing twice is resolved across different browsers and screen sizes.
- Verified that no other functionalities are impacted by this change.

### Notes:
Please review the changes and merge this PR if everything is in order.