### PR TITLE
Removed description img code from bounty desc

### DIFF
--- a/frontend/app/src/bounties/BountyDescription.tsx
+++ b/frontend/app/src/bounties/BountyDescription.tsx
@@ -206,7 +206,6 @@ const BountyDescription = (props: BountiesDescriptionProps) => {
               {props.title?.length > 80 ? '...' : ''}
             </EuiText>
           </div>
-          
         </Description>
         <LanguageContainer>
           {replitLink && (

--- a/frontend/app/src/bounties/BountyDescription.tsx
+++ b/frontend/app/src/bounties/BountyDescription.tsx
@@ -206,17 +206,7 @@ const BountyDescription = (props: BountiesDescriptionProps) => {
               {props.title?.length > 80 ? '...' : ''}
             </EuiText>
           </div>
-          {descriptionImage && (
-            <div className="DescriptionImage">
-              <img
-                src={descriptionImage}
-                alt={'desc'}
-                style={{ objectFit: 'cover' }}
-                height={'100%'}
-                width={'100%'}
-              />
-            </div>
-          )}
+          
         </Description>
         <LanguageContainer>
           {replitLink && (


### PR DESCRIPTION
## Describe your changes
Removed the description image code from the Bounty Header. Could not find any other place where description image was getting affected by removing this part of code.

## Issue ticket number and link
Closes #1242 

## Type of change
Before:

![image](https://github.com/stakwork/sphinx-tribes/assets/91251535/b4c89e3b-fc40-45a0-b451-45200204abd1)


After:

![image](https://github.com/stakwork/sphinx-tribes/assets/91251535/95e433db-577e-4184-b218-81b6d5ef3671)


https://github.com/stakwork/sphinx-tribes/assets/91251535/64ba9d53-f0c6-45e6-995c-26191879bbcf


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend