### PR TITLE
Fix for assigning a hunter if i have manage bounty permissions but someone else posted it

### DIFF
--- a/frontend/app/src/people/widgetViews/summaries/WantedSummary.tsx
+++ b/frontend/app/src/people/widgetViews/summaries/WantedSummary.tsx
@@ -152,7 +152,8 @@ function WantedSummary(props: WantedSummaryProps) {
         estimated_session_length: estimated_session_length,
         show: show,
         type: type,
-        created: created
+        created: created,
+        org_uuid
       };
 
       formSubmit && formSubmit(newValue, true);
@@ -192,7 +193,8 @@ function WantedSummary(props: WantedSummaryProps) {
       estimated_session_length: estimated_session_length,
       show: show,
       type: type,
-      created: created
+      created: created,
+      org_uuid
     };
     formSubmit && formSubmit(newValue, true);
   }, [


### PR DESCRIPTION
Bug fix for assigning hunter if user has manage bounty permission but other user has created the bounty

## Issue ticket number and link
Closes #1266 

## Type of change
bug fix

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend

[Sphinx Community - Google Chrome 2024-01-07 19-56-30.zip](https://github.com/stakwork/sphinx-tribes/files/13853822/Sphinx.Community.-.Google.Chrome.2024-01-07.19-56-30.zip)
