### PR TITLE
fix(#1277):enabled bounty scrolling on org page

### DIFF
--- a/frontend/app/src/pages/tickets/TicketModalPage.tsx
+++ b/frontend/app/src/pages/tickets/TicketModalPage.tsx
@@ -86,17 +86,23 @@ export const TicketModalPage = observer(({ setConnectPerson }: Props) => {
     }
   };
 
-  const prevArrHandler = () => {
-    if (activeListIndex === 0) return;
+  const getBountyIndex = () => {
+    const id = parseInt(bountyId, 10);
+    const index = main.peopleBounties.findIndex((bounty: any) => id === bounty.body.id);
+    return index;
+  };
 
-    const { person, body } = main.peopleBounties[activeListIndex - 1];
+  const prevArrHandler = () => {
+    const index = getBountyIndex();
+    if (index <= 0 || index >= main.peopleBounties.length) return;
+    const { person, body } = main.peopleBounties[index - 1];
     directionHandler(person, body);
   };
 
   const nextArrHandler = () => {
-    if (activeListIndex + 1 > main.peopleBounties?.length) return;
-
-    const { person, body } = main.peopleBounties[activeListIndex + 1];
+    const index = getBountyIndex();
+    if (index + 1 >= main.peopleBounties?.length) return;
+    const { person, body } = main.peopleBounties[index + 1];
     directionHandler(person, body);
   };
 

--- a/frontend/app/src/pages/tickets/TicketModalPage.tsx
+++ b/frontend/app/src/pages/tickets/TicketModalPage.tsx
@@ -24,6 +24,7 @@ export const TicketModalPage = observer(({ setConnectPerson }: Props) => {
 
   const history = useHistory();
   const [connectPersonBody, setConnectPersonBody] = useState<any>();
+  // eslint-disable-next-line no-unused-vars
   const [activeListIndex, setActiveListIndex] = useState<number>(0);
   const [publicFocusIndex, setPublicFocusIndex] = useState(0);
   const [removeNextAndPrev, setRemoveNextAndPrev] = useState(false);


### PR DESCRIPTION
Enabled The scrolling behaviour between various. bounties on the org

--things to note with the scrolling behaviour
scrolling depends upon the array of bounties from the backend without loading more bounties you cannot scroll past the current array with the modal

--cause of the issue 
previous implementation returned incorrect values hence the function could not work

--fix
get the bounty id of the current bounty search the bounty id in the array and get the index , use the index and increment and decrement accordingly

video:
https://www.loom.com/share/c4d65cc968724f478ab8c463ab849cb8

tesed on chrome
fixes #1277