### PR TITLE
fix(#1320):auto populate org

### DIFF
--- a/frontend/app/src/components/form/schema.ts
+++ b/frontend/app/src/components/form/schema.ts
@@ -5,7 +5,6 @@ import {
   estimated_budget_15_min,
   help_wanted_coding_task_schema,
   help_wanted_other_schema,
-  organization
 } from '../../config/bounties';
 import { FormField } from './utils';
 
@@ -28,7 +27,6 @@ const estimated_time = GetValue(estimation);
 const helpType_wanted_coding_task_schema = GetValue(help_wanted_coding_task_schema);
 const helpType_wanted_other_schema = GetValue(help_wanted_other_schema);
 const estimated_budget_15_min_options = GetValue(estimated_budget_15_min);
-const organization_options = GetValue(organization);
 
 // this is source of truth for widget items!
 export const meSchema: FormField[] = [
@@ -676,7 +674,7 @@ export const wantedCodingTaskSchema: FormField[] = [
     name: 'org_uuid',
     label: 'Organization (optional)',
     type: 'select',
-    options: organization_options,
+    options: [],
     validator: strValidatorNotRequired
   },
   {

--- a/frontend/app/src/components/form/schema.ts
+++ b/frontend/app/src/components/form/schema.ts
@@ -4,7 +4,8 @@ import {
   estimation,
   estimated_budget_15_min,
   help_wanted_coding_task_schema,
-  help_wanted_other_schema
+  help_wanted_other_schema,
+  organization
 } from '../../config/bounties';
 import { FormField } from './utils';
 
@@ -27,6 +28,7 @@ const estimated_time = GetValue(estimation);
 const helpType_wanted_coding_task_schema = GetValue(help_wanted_coding_task_schema);
 const helpType_wanted_other_schema = GetValue(help_wanted_other_schema);
 const estimated_budget_15_min_options = GetValue(estimated_budget_15_min);
+const organization_options = GetValue(organization);
 
 // this is source of truth for widget items!
 export const meSchema: FormField[] = [
@@ -674,7 +676,7 @@ export const wantedCodingTaskSchema: FormField[] = [
     name: 'org_uuid',
     label: 'Organization (optional)',
     type: 'select',
-    options: [],
+    options: organization_options,
     validator: strValidatorNotRequired
   },
   {

--- a/frontend/app/src/components/form/schema.ts
+++ b/frontend/app/src/components/form/schema.ts
@@ -4,7 +4,7 @@ import {
   estimation,
   estimated_budget_15_min,
   help_wanted_coding_task_schema,
-  help_wanted_other_schema,
+  help_wanted_other_schema
 } from '../../config/bounties';
 import { FormField } from './utils';
 
@@ -707,7 +707,7 @@ export const wantedCodingTaskSchema: FormField[] = [
   },
   {
     name: 'description',
-    label: 'Description',
+    label: 'Description *',
     type: 'textarea'
   },
   {

--- a/frontend/app/src/config/bounties.ts
+++ b/frontend/app/src/config/bounties.ts
@@ -40,4 +40,3 @@ export const help_wanted_coding_task_schema = [
 
 export const help_wanted_other_schema = ['Troubleshooting', 'Debugging', 'Tutoring'];
 
-export const organization = ['Bounties Platform', 'Second Brain'];

--- a/frontend/app/src/config/bounties.ts
+++ b/frontend/app/src/config/bounties.ts
@@ -39,4 +39,3 @@ export const help_wanted_coding_task_schema = [
 ];
 
 export const help_wanted_other_schema = ['Troubleshooting', 'Debugging', 'Tutoring'];
-

--- a/frontend/app/src/config/bounties.ts
+++ b/frontend/app/src/config/bounties.ts
@@ -39,3 +39,5 @@ export const help_wanted_coding_task_schema = [
 ];
 
 export const help_wanted_other_schema = ['Troubleshooting', 'Debugging', 'Tutoring'];
+
+export const organization = ['Bounties Platform', 'Second Brain'];

--- a/frontend/app/src/people/main/FocusView.tsx
+++ b/frontend/app/src/people/main/FocusView.tsx
@@ -267,10 +267,16 @@ function FocusedView(props: FocusViewProps) {
   }
 
   const [orgName, setOrgName] = useState<string | undefined>();
-
   const getOrganization = async () => {
+    const urlParts = window.location.href.split('/bounties/');
+    const uuid = urlParts.length > 1 ? urlParts[1] : null;
+
+    if (!uuid) {
+      console.error('No UUID found in the URL');
+      return;
+    }
     try {
-      const response = await main.getUserOrganizationByUuid('ck95pe04nncjnaefo08g');
+      const response = await main.getUserOrganizationByUuid(uuid);
       if (response && typeof response.name === 'string') {
         setOrgName(response.name);
       }

--- a/frontend/app/src/people/main/FocusView.tsx
+++ b/frontend/app/src/people/main/FocusView.tsx
@@ -60,12 +60,12 @@ function FocusedView(props: FocusViewProps) {
 
   const isTorSave = canEdit && main.isTorSave();
 
-  const userOrganizations = main.dropDownOrganizations.length
-    ? main.dropDownOrganizations.map((org: Organization) => ({
-        label: toCapitalize(org.name),
-        value: org.uuid
-      }))
-    : [];
+  // const userOrganizations = main.dropDownOrganizations.length
+  //   ? main.dropDownOrganizations.map((org: Organization) => ({
+  //       label: toCapitalize(org.name),
+  //       value: org.uuid
+  //     }))
+  //   : [];
 
   function isNotHttps(url: string | undefined) {
     if (main.isTorSave() || url?.startsWith('http://')) {
@@ -266,7 +266,28 @@ function FocusedView(props: FocusViewProps) {
       props?.ReCallBounties();
   }
 
+  const [orgName, setOrgName] = useState<string | undefined>();
+
+  const getOrganization = async () => {
+    try {
+      const response = await main.getUserOrganizationByUuid('ck95pe04nncjnaefo08g');
+      if (response && typeof response.name === 'string') {
+        setOrgName(response.name);
+      }
+    } catch (error) {
+      console.error('Error fetching organization:', error);
+    }
+  };
+
+  useEffect(() => {
+    getOrganization();
+  });
+
   let initialValues: any = {};
+
+  const altInitialValue: any = {
+    org_uuid: orgName || 'Bounties Platform'
+  };
 
   const personInfo = canEdit ? ui.meInfo : person;
 
@@ -313,6 +334,8 @@ function FocusedView(props: FocusViewProps) {
           initialValues[s.name] = wanted[s.name];
         });
       }
+    } else {
+      initialValues = altInitialValue;
     }
   }
 
@@ -350,10 +373,9 @@ function FocusedView(props: FocusViewProps) {
     }
   }
 
-  // set user organizations
-  if (config?.schema?.[0]?.['defaultSchema']?.[0]?.['options']) {
-    config.schema[0]['defaultSchema'][0]['options'] = userOrganizations;
-  }
+  // if (config?.schema?.[0]?.['defaultSchema']?.[0]?.['options']) {
+  //   config.schema[0]['defaultSchema'][0]['options'] = userOrganizations;
+  // }
 
   return (
     <div

--- a/frontend/app/src/people/main/FocusView.tsx
+++ b/frontend/app/src/people/main/FocusView.tsx
@@ -286,9 +286,13 @@ function FocusedView(props: FocusViewProps) {
 
   let initialValues: any = {};
 
-  const altInitialValue: any = {
-    org_uuid: orgName || 'Bounties Platform'
-  };
+  let altInitialValue = {};
+
+  if (window.location.href.includes('/org')) {
+    altInitialValue = {
+      org_uuid: orgName || 'Bounties Platform'
+    };
+  }
 
   const personInfo = canEdit ? ui.meInfo : person;
 

--- a/frontend/app/src/people/main/FocusView.tsx
+++ b/frontend/app/src/people/main/FocusView.tsx
@@ -4,7 +4,6 @@ import { cloneDeep } from 'lodash';
 import { observer } from 'mobx-react-lite';
 import { FocusViewProps } from 'people/interfaces';
 import { EuiGlobalToastList } from '@elastic/eui';
-import { Organization } from 'store/main';
 import { Box } from '@mui/system';
 import { useStores } from '../../store';
 import Form from '../../components/form/bounty';
@@ -17,11 +16,7 @@ import {
 import WantedSummary from '../widgetViews/summaries/WantedSummary';
 import { useIsMobile } from '../../hooks';
 import { dynamicSchemasByType } from '../../components/form/schema';
-import {
-  convertLocaleToNumber,
-  extractRepoAndIssueFromIssueUrl,
-  toCapitalize
-} from '../../helpers';
+import { convertLocaleToNumber, extractRepoAndIssueFromIssueUrl } from '../../helpers';
 import { B, BWrap } from './style';
 
 // selected bounty popup window


### PR DESCRIPTION
With this PR :
-Post bounty Modal auto populates the organization name
https://www.loom.com/share/e7323ceede244efd9b952b1c02820782?sid=82b6fce7-ef00-4a62-8220-c01447f7e3c8

--Notes On Current Implementation
the default value on the select comes from the api call getOrganizationByUuid , drop down values come from The Schema.ts file they act as mock organization data , alternatively we can call getOrganizationsById or create and alteranative function  getAllOrganizations that will populate this the dropdown , note the commented code in this PR on file FocusView.tsx references to dropDown option which is an empty array ,that can be used in the future to prefetch dropdown data from backend

this has been tested on chrome and firefox , implements #1320 