### PR TITLE
fix(#1360):fix for default profile picture

### DIFF
--- a/frontend/app/src/people/main/bountyModal/BountyModal.tsx
+++ b/frontend/app/src/people/main/bountyModal/BountyModal.tsx
@@ -22,6 +22,7 @@ export const BountyModal = ({ basePath, fromPage, bountyOwner }: BountyModalProp
   const [bounty, setBounty] = useState<PersonBounty[]>([]);
   const [afterEdit, setAfterEdit] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [ToDisplay, setToDisplay] = useState<any>();
 
   const personToDisplay = fromPage === 'usertickets' ? bountyOwner : person;
 
@@ -44,7 +45,13 @@ export const BountyModal = ({ basePath, fromPage, bountyOwner }: BountyModalProp
       if ((wantedId && !bounty.length) || afterEdit) {
         try {
           const bountyData = await main.getBountyById(Number(wantedId));
+          console.log(bountyData, 'bd');
           setBounty(bountyData);
+          if (personToDisplay === undefined) {
+            setToDisplay(bountyData[0].person);
+          } else {
+            setToDisplay(personToDisplay);
+          }
         } catch (error) {
           console.error('Error fetching bounty:', error);
         } finally {
@@ -52,7 +59,7 @@ export const BountyModal = ({ basePath, fromPage, bountyOwner }: BountyModalProp
         }
       }
     },
-    [bounty, main, wantedId]
+    [bounty, main, wantedId, personToDisplay]
   );
 
   useEffect(() => {
@@ -115,7 +122,7 @@ export const BountyModal = ({ basePath, fromPage, bountyOwner }: BountyModalProp
       }}
     >
       <FocusedView
-        person={personToDisplay}
+        person={ToDisplay}
         personBody={person}
         canEdit={false}
         selectedIndex={Number(wantedIndex)}

--- a/frontend/app/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
+++ b/frontend/app/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
@@ -137,7 +137,7 @@ describe('MobileView component', () => {
     const nameTagProps = {
       owner_alias: 'Test Owner',
       img: 'test-image.jpg',
-      created: 1610000000, 
+      created: 1610000000,
       id: 180,
       owner: 'Test-Owner',
       owner_pubkey: 'abc100',

--- a/frontend/app/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
+++ b/frontend/app/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
@@ -134,17 +134,14 @@ describe('MobileView component', () => {
   });
 
   it('should render the NameTag with correct props', () => {
-    // Define props for the NameTag
     const nameTagProps = {
       owner_alias: 'Test Owner',
       img: 'test-image.jpg',
-      created: 1610000000, // UNIX timestamp
+      created: 1610000000, 
       id: 180,
       owner: 'Test-Owner',
       owner_pubkey: 'abc100',
       widget: 'wanted'
-
-      // ... other props ...
     };
     render(<MobileView {...defaultProps} nametag={<NameTag {...nameTagProps} />} />);
 

--- a/frontend/app/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
+++ b/frontend/app/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { CodingBountiesProps } from 'people/interfaces';
 import React from 'react';
+import NameTag from 'people/utils/NameTag';
 import MobileView from '../CodingBounty';
 
 describe('MobileView component', () => {
@@ -130,5 +131,23 @@ describe('MobileView component', () => {
 
     const iCanHelp = screen.getByText('Share to Twitter');
     expect(iCanHelp).toBeInTheDocument();
+  });
+
+  it('should render the NameTag with correct props', () => {
+    // Define props for the NameTag
+    const nameTagProps = {
+      owner_alias: 'Test Owner',
+      img: 'test-image.jpg',
+      created: 1610000000, // UNIX timestamp
+      id: 180,
+      owner: 'Test-Owner',
+      owner_pubkey: 'abc100',
+      widget: 'wanted'
+
+      // ... other props ...
+    };
+    render(<MobileView {...defaultProps} nametag={<NameTag {...nameTagProps} />} />);
+
+    expect(screen.getByText(nameTagProps.owner_alias)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
fixed the default profile picture appearing on bounty description

--cause of the issue 
the state of the object holding the data does not update

--fix
getting the data directly from bounty modal from bounty data mitigating the bug

loom video:https://www.loom.com/share/e115fda066b2480b9179de8515bc0827

tested on chrome 
test file has been updated

fixes: #1360