### PR TITLE
Enabled Scrolling for Organization Bounties page

### DIFF
--- a/frontend/app/src/pages/tickets/TicketModalPage.tsx
+++ b/frontend/app/src/pages/tickets/TicketModalPage.tsx
@@ -32,6 +32,27 @@ export const TicketModalPage = observer(({ setConnectPerson }: Props) => {
   const [activeBounty, setActiveBounty] = useState<PersonBounty[]>([]);
   const [visible, setVisible] = useState(false);
   const [isDeleted, setisDeleted] = useState(false);
+  const [isOrgBounties, setIsOrgBounties] = useState(false);
+  const [orgBounties, setOrgBounties] = useState<any>({});
+
+  const { state } = location;
+
+  type OrgTicketModalState = {
+    uuid?: string;
+  };
+
+  const uuid = (state as OrgTicketModalState)?.uuid || '';
+
+  useEffect(() => {
+    (async () => {
+      if (uuid) {
+        const res = await main.getOrganizationBounties(uuid, { page: 1, resetPage: true });
+        setOrgBounties(res);
+        setIsOrgBounties(true);
+      }
+      console.log(orgBounties, 'as');
+    })();
+  }, [main, uuid]);
 
   const isMobile = useIsMobile();
 
@@ -89,22 +110,39 @@ export const TicketModalPage = observer(({ setConnectPerson }: Props) => {
 
   const getBountyIndex = () => {
     const id = parseInt(bountyId, 10);
-    const index = main.peopleBounties.findIndex((bounty: any) => id === bounty.body.id);
+    let index;
+    if (isOrgBounties) {
+      index = orgBounties.findIndex((bounty: any) => id === bounty.body.id);
+    } else {
+      index = main.peopleBounties.findIndex((bounty: any) => id === bounty.body.id);
+    }
     return index;
   };
 
   const prevArrHandler = () => {
     const index = getBountyIndex();
-    if (index <= 0 || index >= main.peopleBounties.length) return;
-    const { person, body } = main.peopleBounties[index - 1];
-    directionHandler(person, body);
+    if (isOrgBounties) {
+      if (index <= 0 || index >= orgBounties.length) return;
+      const { person, body } = orgBounties[index - 1];
+      directionHandler(person, body);
+    } else {
+      if (index <= 0 || index >= main.peopleBounties.length) return;
+      const { person, body } = main.peopleBounties[index - 1];
+      directionHandler(person, body);
+    }
   };
 
   const nextArrHandler = () => {
     const index = getBountyIndex();
-    if (index + 1 >= main.peopleBounties?.length) return;
-    const { person, body } = main.peopleBounties[index + 1];
-    directionHandler(person, body);
+    if (isOrgBounties) {
+      if (index + 1 >= orgBounties?.length) return;
+      const { person, body } = orgBounties[index + 1];
+      directionHandler(person, body);
+    } else {
+      if (index + 1 >= main.peopleBounties?.length) return;
+      const { person, body } = main.peopleBounties[index + 1];
+      directionHandler(person, body);
+    }
   };
 
   if (isMobile) {

--- a/frontend/app/src/pages/tickets/org/OrgTickets.tsx
+++ b/frontend/app/src/pages/tickets/org/OrgTickets.tsx
@@ -73,7 +73,7 @@ function OrgBodyComponent() {
   };
 
   const onPanelClick = (person: any, item: any) => {
-    history.push(`/bounty/${item.id}`);
+    history.push(`/bounty/${item.id}`, { uuid });
   };
 
   if (loading) {


### PR DESCRIPTION
Enabled Scrolling for Organization Bounties Page.


## Cause of issue
Instead of getting organization bounties it was scrolling through user bounties array due to which incorrect bounties where shown for organization bounty page.

## Describe your changes
Passed uuid from OrgTickets to TicketModalPage and made call to get organization bounties to loop in next and prev array handler.

## Issue ticket number and link
https://github.com/stakwork/sphinx-tribes/issues/1277

## Type of change
UI

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend