### PR TITLE
Redisplay bounties after cleared search on homepage 

### DIFF
--- a/frontend/app/src/people/widgetViews/BountyHeader.tsx
+++ b/frontend/app/src/people/widgetViews/BountyHeader.tsx
@@ -382,6 +382,18 @@ const BountyHeader = ({
     );
   }, [checkboxIdToSelectedMapLanguage, checkboxIdToSelectedMap]);
 
+  let timeoutId;
+  const onChangeSearch = (e: any) => {
+    ui.setSearchText(e);
+    clearTimeout(timeoutId);
+    // Set a new timeout to wait for user to pause typing
+    timeoutId = setTimeout(() => {
+      if (ui.searchText === '') {
+        main.getPeopleBounties({ page: 1, resetPage: true, ...checkboxIdToSelectedMap });
+      }
+    }, 1000);
+  };
+
   return (
     <>
       {!isMobile ? (
@@ -417,6 +429,7 @@ const BountyHeader = ({
                 }}
               />
               <SearchBar
+                data-testid="search-bar"
                 name="search"
                 type="search"
                 placeholder={`Search across ${activeBounty} Bounties`}
@@ -429,9 +442,7 @@ const BountyHeader = ({
                   fontFamily: 'Barlow',
                   color: color.text2
                 }}
-                onChange={(e: any) => {
-                  ui.setSearchText(e);
-                }}
+                onChange={onChangeSearch}
                 onKeyUp={(e: any) => {
                   if (e.key === 'Enter' || e.keyCode === 13) {
                     main.getPeopleBounties({ page: 1, resetPage: true });

--- a/frontend/app/src/people/widgetViews/__tests__/BountyHeader.spec.tsx
+++ b/frontend/app/src/people/widgetViews/__tests__/BountyHeader.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import BountyHeader from '../BountyHeader';
 import { BountyHeaderProps } from '../../interfaces';
@@ -114,5 +114,36 @@ describe('BountyHeader Component', () => {
       fireEvent.click(checkbox);
       expect(mockProps.onChangeLanguage).toHaveBeenCalledWith(language);
     });
+  });
+
+  jest.useFakeTimers();
+
+  it('should call main.getPeopleBounty when search text is empty', async () => {
+    const { getByTestId } = render(<BountyHeader {...mockProps} />);
+
+    // Simulate typing in the search bar
+    fireEvent.change(getByTestId('search-bar'), { target: { value: 'Test' } });
+
+    // Check if the search text is updated
+    expect(getByTestId('search-bar')).toHaveValue('Test');
+
+    // const getPeopleBountiesMock = jest.fn();
+
+    // Simulate clicking on the close icon
+    fireEvent.change(getByTestId('search-bar'), { target: { value: '' } });
+
+    expect(getByTestId('search-bar')).toHaveValue('');
+
+    const getPeopleBountiesSpy = jest.spyOn(mainStore, 'getPeopleBounties');
+
+    act(() => {
+      jest.advanceTimersByTime(2001);
+    });
+    // Expect that getPeopleBounties has been called
+    expect(await getPeopleBountiesSpy).toHaveBeenCalled();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers(); // Restore real timers after all tests are done
   });
 });


### PR DESCRIPTION
## Problem :  No bounties redisplay with selected filter on home page after cleared the search

## Issue ticket number and link
- Issue Ticket Number: #1359
- issue Ticket [Link](https://github.com/stakwork/sphinx-tribes/issues/1359)

## Evidance
- This is the [evidance link](https://www.loom.com/share/dee6a111bb0e4a17a477780eae01e08c?sid=25b578a8-1d41-442b-b204-f7e88d2d0f1b) 

## Changes

 ## 1. BountyHeader.tsx
 **Search Bar Event Handling:**
   - Updated the `onChange` event for the search bar to utilize the new `onChangeSearch` function.
   - The `onChangeSearch` function now sets the search text, clears the existing timeout, and sets a new timeout for delayed processing.
  - This ensures that the `main.getPeopleBounties` function is only called after the user has cleared the text and have taken a pause .
  - Implemented a timeout mechanism to wait for the user to pause typing before triggering updates.


 ## 2. BountyHeader.spec.tsx
1. **Simulating User Action:**
   - Utilized the `fireEvent.change` method to simulate the user action of typing in the search bar.
   - Checked if the search text is correctly updated.

2. **Clearing the Search Text:**
   - Triggered the change event to set the search text to an empty string, simulating the user clearing the search bar.

3. **Timing Control:**
   - Used `jest.useFakeTimers()` to control timers within the test environment.
   - Advanced timers by 2001 milliseconds using `jest.advanceTimersByTime(2001)`.

4. **Expectation:**
   - Expectation set for the `main.getPeopleBounties` function to be called upon clearing the search text.

5. **Cleanup:**
   - Applied `jest.useRealTimers()` after the test to restore real timers.

