### PR TITLE
fix: Trim spaces in org names and fix org dropdown issue 

### DIFF
--- a/frontend/app/src/helpers/__test__/helpers.spec.ts
+++ b/frontend/app/src/helpers/__test__/helpers.spec.ts
@@ -209,6 +209,16 @@ describe('testing helpers', () => {
       const capitalizeString = toCapitalize('hello test sphinx');
       expect(capitalizeString).toBe('Hello Test Sphinx');
     });
+
+    test('test to capitalize string with extra space at the end', () => {
+      const capitalizeString = toCapitalize('hello test sphinx    ');
+      expect(capitalizeString).toBe('Hello Test Sphinx');
+    });
+
+    test('test to capitalize string with extra space between', () => {
+      const capitalizeString = toCapitalize('hello test    sphinx');
+      expect(capitalizeString).toBe('Hello Test Sphinx');
+    });
   });
   describe('spliceOutPubkey', () => {
     test('test that it returns pubkey from a pubkey:route_hint string', () => {

--- a/frontend/app/src/helpers/helpers-extended.ts
+++ b/frontend/app/src/helpers/helpers-extended.ts
@@ -271,8 +271,10 @@ export const userHasManageBountyRoles = (bountyRoles: any[], userRoles: any[]): 
 export const toCapitalize = (word: string): string => {
   if (!word.length) return word;
 
-  const wordString = word.split(' ');
-  const capitalizeStrings = wordString.map((w: string) => w[0].toUpperCase() + w.slice(1));
+  const wordString = word.trim().split(' ');
+  const capitalizeStrings = wordString
+    .filter((w) => !!w)
+    ?.map((w: string) => w[0].toUpperCase() + w.slice(1));
 
   const result = capitalizeStrings.join(' ');
   return result;

--- a/frontend/app/src/people/widgetViews/OrganizationView.tsx
+++ b/frontend/app/src/people/widgetViews/OrganizationView.tsx
@@ -175,7 +175,6 @@ const Organizations = (props: { person: Person }) => {
     setIsLoading(true);
     if (ui.selectedPerson) {
       await main.getUserOrganizations(ui.selectedPerson);
-      await main.getUserDropdownOrganizations(ui.selectedPerson);
     }
     setIsLoading(false);
   }, [main, ui.selectedPerson]);


### PR DESCRIPTION
## Describe your changes
Trim spaces in org names and fix org dropdown issue

## Issue ticket number and link
closes #1339 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend

https://github.com/stakwork/sphinx-tribes/assets/93755484/983d71f8-1b68-473e-b03a-b2c08e0e1dac

### Org dropdown fix
https://github.com/stakwork/sphinx-tribes/assets/93755484/ac000741-750f-4615-8a10-f1c65c545389

