### PR TITLE
fix(clear-search): Fixed Clear Search When Someone Clicks Out of The Page.

### DIFF
--- a/frontend/app/src/store/__test__/ui.spec.tsx
+++ b/frontend/app/src/store/__test__/ui.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { UiStore } from '../ui.ts';
+
+describe('UiStore', () => {
+  let uiStore: UiStore;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    uiStore = new UiStore();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null!;
+  });
+
+  it('clears search text when clicking outside of search input', () => {
+    const { getByTestId } = render(
+      <div>
+        <input
+          data-testid="search-input"
+          value={uiStore.searchText}
+          onChange={(e) => uiStore.setSearchText(e.target.value)}
+        />
+        <button data-testid="outside-button">Outside</button>
+      </div>
+    );
+
+    const searchInput = getByTestId('search-input') as HTMLInputElement;
+    const outsideButton = getByTestId('outside-button') as HTMLButtonElement;
+
+    fireEvent.change(searchInput, { target: { value: 'Test' } });
+
+    expect(uiStore.searchText).toBe('test');
+
+    fireEvent.click(outsideButton);
+
+    expect(uiStore.searchText).toBe('');
+  });
+});

--- a/frontend/app/src/store/ui.ts
+++ b/frontend/app/src/store/ui.ts
@@ -41,11 +41,23 @@ export interface MeInfo {
 
 export type MeData = MeInfo | null;
 
-class UiStore {
+export class UiStore {
   ready = false;
 
   constructor() {
     makeAutoObservable(this);
+    document.addEventListener('click', this.handleDocumentClick);
+  }
+
+  handleDocumentClick = (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (!target.closest('.search-input-wrapper')) {
+      this.clearSearchText();
+    }
+  };
+
+  clearSearchText() {
+    this.searchText = '';
   }
 
   setReady(ready: boolean) {


### PR DESCRIPTION
### Problem:
The application retains the search term in the UI state when users navigate away from the profile page to either the `people page` or the `bounty homepage` and other `routes`. This behavior is inconsistent with typical user expectations where a search term should be cleared upon navigating to a different page.

### Expected Behavior:
When a user navigates away from the profile page, the search term entered should be automatically cleared. This ensures that when the user visits the `people` page or the `bounty homepage` and other `all routes`, they are presented with a fresh state, unfiltered by their previous search.

## Issue ticket number and link:
- **Ticket Number:** [ 1409 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes/issues/1409 ]

### Solution:
The solution involves adding an event listener in the `UiStore` class constructor to detect click events on the document. If a click event occurs outside the search input (`.search-input-wrapper`), the `clearSearchText` method is called to reset the `searchText` state to an empty string.

### Changes:
 - Modified the `UiStore` class constructor to include a document click event listener.
 - Implemented `handleDocumentClick`, a method to check the target of click events and determine if they occur outside the search input area.
 - Developed `clearSearchText` method to reset the search text.

### Evidence:
 Please see the attached video as evidence.
- Before Demo: [Link](https://www.loom.com/share/af20a272dc534e78bc40a559eb5a14f1)
- After Demo: [Link ](https://www.loom.com/share/2b1bbf712e334beaa3f3795b6cd1a72a)

### Testing:
- **Click-based Navigation**: Clicking on various elements and navigating to different pages to verify that the search term is cleared.
- **Keyboard Navigation**: Ensuring that non-click based navigations also result in the search term being cleared.
- **Edge Cases**: Testing with rapid navigation, back and forth between pages, and refreshing pages to observe the persistence of the search term.

