### PR TITLE
fix: broken create bounty modal 

### DIFF
--- a/frontend/app/src/components/form/bounty/index.tsx
+++ b/frontend/app/src/components/form/bounty/index.tsx
@@ -437,7 +437,7 @@ function Form(props: FormProps) {
                 {schemaData.step !== 1 && (
                   <>
                     <SchemaTagsContainer>
-                      <div className="LeftSchema">
+                      <div className="LeftSchema" style={{ width: '292px' }}>
                         {schema
                           .filter((item: any) => schemaData.schema.includes(item.name))
                           .map((item: FormField) => (
@@ -497,7 +497,7 @@ function Form(props: FormProps) {
                             />
                           ))}
                       </div>
-                      <div className="RightSchema">
+                      <div className="RightSchema" style={{ width: '292px' }}>
                         {schema
                           .filter((item: any) => schemaData.schema2.includes(item.name))
                           .map((item: FormField) => (

--- a/frontend/app/src/components/form/inputs/TextAreaInput.tsx
+++ b/frontend/app/src/components/form/inputs/TextAreaInput.tsx
@@ -16,6 +16,9 @@ const StyleOnText = {
   }
 };
 
+const defaultHeight = '135px';
+const defaultWidth = '100%';
+
 interface styledProps {
   color?: any;
 }
@@ -98,14 +101,14 @@ export default function TextAreaInput({
         className={active ? 'euiFormRow_active' : (value ?? '') === '' ? '' : 'euiFormRow_filed'}
         border={borderType}
         label={label}
-        height={StyleOnText[label].height}
-        width={StyleOnText[label].width}
+        height={StyleOnText[label]?.height ?? defaultHeight}
+        width={StyleOnText[label]?.width ?? defaultWidth}
       >
         <R>
           <FieldTextArea
             color={color}
-            height={StyleOnText[label].height}
-            width={StyleOnText[label].width}
+            height={StyleOnText[label]?.height ?? defaultHeight}
+            width={StyleOnText[label]?.width ?? defaultWidth}
             name="first"
             value={value || ''}
             readOnly={readOnly || false}

--- a/frontend/app/src/components/form/inputs/index.tsx
+++ b/frontend/app/src/components/form/inputs/index.tsx
@@ -139,7 +139,7 @@ export const FieldTextArea = styled(EuiTextArea)<styledProps>`
   background-color: ${(p: any) => p?.color && p.color.pureWhite} !important;
   background: ${(p: any) => p?.color && p.color.pureWhite} !important;
   max-width: 900px;
-  width: 292px;
+  width: 100%;
   min-height: 167px;
   color: ${(p: any) => p?.color && p.color.pureBlack} !important;
   box-shadow: none !important;


### PR DESCRIPTION
### Describe your changes

### Problem

- The Input fields were created with a default width of `292px` which cannot apply to all use cases
- Also, I realized that the edit profile modal is currently breaking on `people-test. sphinx.chat` 

### Solution 
All modals now working properly

![123](https://github.com/stakwork/sphinx-tribes/assets/117433403/bf32a15d-cb13-450d-aa8f-8b72ed734ebe)

![1234](https://github.com/stakwork/sphinx-tribes/assets/117433403/5d8d3d60-ec41-49b0-9036-1e005a5eef05)


- [x] Ui Bug fix 
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend