### PR TITLE
fix(people): use unique `id` person property for `key`

### DIFF
--- a/frontend/app/src/people/main/Body.tsx
+++ b/frontend/app/src/people/main/Body.tsx
@@ -162,7 +162,7 @@ function BodyComponent() {
         {(ui.searchText ? people : filterResult).map((t: any) => (
           <Person
             {...t}
-            key={t.owner_pubkey}
+            key={t.id}
             small={isMobile}
             squeeze={screenWidth < 1420}
             selected={ui.selectedPerson === t.id}


### PR DESCRIPTION
 ## Describe your changes

There are duplicated items in people data with the same `owner_pubkey`. These items leads to duplicating cards in the search result. Use `id` field as it is strongly unique.

## Issue ticket number and link

Fix: #1436

## Type of change

Bug fix (non-breaking change which fixes an issue)

https://jam.dev/c/051c20e9-b431-4fff-84cb-6fc20fece577