### PR TITLE
fix(ui): keep `searchText` in local storage

### DIFF
--- a/frontend/app/src/store/ui.ts
+++ b/frontend/app/src/store/ui.ts
@@ -57,6 +57,7 @@ class UiStore {
     this.tags = t;
   }
 
+  @persist
   searchText = '';
   setSearchText(s: string) {
     this.searchText = s.toLowerCase();


### PR DESCRIPTION
## Describe your changes
Add `@persist` decorator to ui store's `searchText` field

## Issue ticket number and link
Fix: #1437

## Type of change

Bug fix (non-breaking change which fixes an issue)

https://jam.dev/c/972b9905-e5c8-41a5-a9fd-1515b9a74e75