### PR TITLE
Add workflow to auto-add issues to bounties platform project

### DIFF
--- a/.github/workflows/add_issues_to_project.yml
+++ b/.github/workflows/add_issues_to_project.yml
@@ -1,0 +1,19 @@
+# Since we've separated the frontend from the backend, we must track 2 repos in our bounties platform project. The free version of github only allows the project to reference one repo for free. So we are implementing this workflow to have issues be auto-added to the bounties platform project board from a second repo.
+
+name: Add issues labeled `bounties` to bounties platform project
+
+on:
+  issues:
+    types:
+      - opened
+      
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/stakwork/projects/24
+          github-token: ${{ secrets.ADD_TO_PROJECT }}	
+          labeled: bounties


### PR DESCRIPTION
Since we've separated the frontend from the backend, we must track 2 repos in our bounties platform project. The free version of github only allows the project to reference one repo for free. So we are implementing this workflow to have issues be auto-added to the bounties project board from a second repo.

This workflow uses a PAT that must be renewed 1/25/25.