### PR TITLE
removed description restrictions from org

### DIFF
--- a/handlers/organization_test.go
+++ b/handlers/organization_test.go
@@ -111,7 +111,6 @@ func TestUnitCreateOrEditOrganization(t *testing.T) {
 			description string
 			wantStatus  int
 		}{
-			{"empty description", "", http.StatusBadRequest},
 			{"long description", strings.Repeat("a", 121), http.StatusBadRequest},
 		}
 

--- a/handlers/organizations.go
+++ b/handlers/organizations.go
@@ -51,13 +51,6 @@ func (oh *organizationHandler) CreateOrEditOrganization(w http.ResponseWriter, r
 		return
 	}
 
-	if len(org.Description) == 0 || len(org.Description) > 120 {
-		fmt.Printf("invalid organization name %s\n", org.Description)
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode("Error: organization description must be present and should not exceed 120 character")
-		return
-	}
-
 	if pubKeyFromAuth != org.OwnerPubKey {
 		hasRole := db.UserHasAccess(pubKeyFromAuth, org.Uuid, db.EditOrg)
 		if !hasRole {

--- a/handlers/organizations.go
+++ b/handlers/organizations.go
@@ -51,6 +51,13 @@ func (oh *organizationHandler) CreateOrEditOrganization(w http.ResponseWriter, r
 		return
 	}
 
+	if len(org.Description) > 120 {
+		fmt.Printf("invalid organization name %s\n", org.Description)
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode("Error: organization description should not exceed 120 character")
+		return
+	}
+
 	if pubKeyFromAuth != org.OwnerPubKey {
 		hasRole := db.UserHasAccess(pubKeyFromAuth, org.Uuid, db.EditOrg)
 		if !hasRole {


### PR DESCRIPTION
Issue:#1490
I have edited the code block responsible for the restriction, this now only checks if the description is within 120 characters

```Golang
if len(org.Description) > 120 {
		fmt.Printf("invalid organization name %s\n", org.Description)
		w.WriteHeader(http.StatusBadRequest)
		json.NewEncoder(w).Encode("Error: organization description should not exceed 120 character")
		return
	}
```

This will enable edit/create org with blank description