### PR TITLE
Remove unsettled payments from Payment history

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1814,7 +1814,7 @@ func (db database) GetPaymentHistory(org_uuid string, r *http.Request) []Payment
 
 	limitQuery = fmt.Sprintf("LIMIT %d  OFFSET %d", limit, offset)
 
-	query := `SELECT * FROM payment_histories WHERE org_uuid = '` + org_uuid + `' ORDER BY created DESC`
+	query := `SELECT * FROM payment_histories WHERE org_uuid = '` + org_uuid + `' AND status = true ORDER BY created DESC`
 
 	db.db.Raw(query + " " + limitQuery).Find(&payment)
 	return payment

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,7 +28,7 @@ func GetPaginationParams(r *http.Request) (int, int, string, string, string) {
 		intPage = 1
 	}
 	if intLimit == 0 {
-		intLimit = -1
+		intLimit = 1
 	}
 	if sortBy == "" {
 		sortBy = "created"


### PR DESCRIPTION
## Describe your changes

This PR removes unsettled payments from being displayed on the payment history and sets the default pagination limit to 1.

## Issue ticket number and link

Closes https://github.com/stakwork/sphinx-tribes-frontend/issues/276

Loom Video

https://www.loom.com/share/f225e7c12c7f4d6b96a0f52f5ff582aa

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [ ] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend