### PR TITLE
Added mutex lock to budget withdrawal to prevent race conditions

### DIFF
--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -543,6 +543,9 @@ func (h *bountyHandler) MakeBountyPayment(w http.ResponseWriter, r *http.Request
 }
 
 func (h *bountyHandler) BountyBudgetWithdraw(w http.ResponseWriter, r *http.Request) {
+	var m sync.Mutex
+	m.Lock()
+
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
 
@@ -599,6 +602,8 @@ func (h *bountyHandler) BountyBudgetWithdraw(w http.ResponseWriter, r *http.Requ
 		errMsg := formatPayError("Could not pay lightning invoice")
 		json.NewEncoder(w).Encode(errMsg)
 	}
+
+	m.Unlock()
 }
 
 func formatPayError(errorMsg string) db.InvoicePayError {


### PR DESCRIPTION
## Describe your changes

This PR adds a Lock for each business logic request, to prevent race conditions on the budget withdrawal.

## Issue ticket number and link

Closes #1600 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device