### PR TITLE
Changed sign in challenge to random string

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1778,13 +1778,13 @@ func (db database) GetOrganizationStatusBudget(org_uuid string) StatusBudget {
 	orgBudget := db.GetOrganizationBudget(org_uuid)
 
 	var openBudget uint
-	db.db.Model(&Bounty{}).Where("assignee = '' ").Select("SUM(price)").Row().Scan(&openBudget)
+	db.db.Model(&Bounty{}).Where("assignee = '' ").Where("paid != true").Select("SUM(price)").Row().Scan(&openBudget)
 
 	var assignedBudget uint
-	db.db.Model(&Bounty{}).Where("assignee != '' ").Select("SUM(price)").Row().Scan(&assignedBudget)
+	db.db.Model(&Bounty{}).Where("assignee != '' ").Where("paid != true").Select("SUM(price)").Row().Scan(&assignedBudget)
 
 	var completedBudget uint
-	db.db.Model(&Bounty{}).Where("completed = true ").Select("SUM(price)").Row().Scan(&completedBudget)
+	db.db.Model(&Bounty{}).Where("completed = true ").Where("paid != true").Select("SUM(price)").Row().Scan(&completedBudget)
 
 	statusBudget := StatusBudget{
 		OrgUuid:         org_uuid,

--- a/db/store.go
+++ b/db/store.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi"
@@ -132,9 +133,12 @@ func (s StoreData) GetChallengeCache(key string) (string, error) {
 }
 
 func Ask(w http.ResponseWriter, r *http.Request) {
+	var m sync.Mutex
+	m.Lock()
+
 	ts := strconv.Itoa(int(time.Now().Unix()))
 	h := []byte(ts)
-	// h := blake2b.Sum256([]byte(ts))
+
 	challenge := base64.URLEncoding.EncodeToString(h[:])
 
 	Store.SetChallengeCache(challenge, ts)
@@ -144,6 +148,8 @@ func Ask(w http.ResponseWriter, r *http.Request) {
 		"challenge": challenge,
 		"ts":        ts,
 	})
+
+	m.Unlock()
 }
 
 type VerifyPayload struct {

--- a/db/store.go
+++ b/db/store.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/patrickmn/go-cache"
+	"github.com/rs/xid"
 	"github.com/stakwork/sphinx-tribes/auth"
 	"github.com/stakwork/sphinx-tribes/config"
 )
@@ -137,9 +137,7 @@ func Ask(w http.ResponseWriter, r *http.Request) {
 	m.Lock()
 
 	ts := strconv.Itoa(int(time.Now().Unix()))
-	h := []byte(ts)
-
-	challenge := base64.URLEncoding.EncodeToString(h[:])
+	challenge := xid.New().String()
 
 	Store.SetChallengeCache(challenge, ts)
 
@@ -148,7 +146,6 @@ func Ask(w http.ResponseWriter, r *http.Request) {
 		"challenge": challenge,
 		"ts":        ts,
 	})
-
 	m.Unlock()
 }
 


### PR DESCRIPTION
## Describe your changes

This PR changes the sign-in challenge from time in UNIX to a random string to fix duplicate sign-in for close time intervals.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device