### PR TITLE
Fixed: Update workspaces Creation Handler

### DIFF
--- a/cypress/e2e/01_workspaces.cy.ts
+++ b/cypress/e2e/01_workspaces.cy.ts
@@ -1,20 +1,24 @@
 import { User, HostName, Workspaces } from '../support/objects/objects';
 
-
 describe('Create Workspaces', () => {
     it('passes', () => {
         cy.upsertlogin(User).then(value => {
-            for(let i = 0; i <= 2; i++) {
+            for(let i = 0; i < Workspaces.length; i++) {
                 cy.request({
                     method: 'POST',
-                    url: `${HostName}/workspaces/`,
+                    url: `${HostName}/workspaces`,
                     headers: { 'x-jwt': `${value}` },
-                    body: Workspaces[i]
-                }).its('body').should('have.property', 'name', Workspaces[i].name.trim());
+                    body: Workspaces[i],
+                    failOnStatusCode: false
+                }).then((response) => {
+                    expect(response.status).to.eq(200);
+                    expect(response.body).to.have.property('name', Workspaces[i].name.trim());
+                });
             }
-        })
-    })
-})
+        });
+    });
+});
+
 
 describe('Edit Mission', () => {
     it('passes', () => {

--- a/handlers/workspaces.go
+++ b/handlers/workspaces.go
@@ -111,21 +111,22 @@ func (oh *workspaceHandler) CreateOrEditWorkspace(w http.ResponseWriter, r *http
 
 		name := workspace.Name
 
-		// check if the organization name already exists
-		workspace_same_name := oh.db.GetWorkspaceByName(name)
-
-		if workspace_same_name.Name == name && workspace_same_name.Uuid != workspace.Uuid {
-			w.WriteHeader(http.StatusUnauthorized)
-			json.NewEncoder(w).Encode("Workspace name already exists - " + name + " " + workspace.Uuid + " | " + workspace_same_name.Uuid)
+		// check if the workspace name already exists
+		workspaceSameName := oh.db.GetWorkspaceByName(name)
+		if workspaceSameName.Name == name {
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode("Workspace name already exists - " + name)
 			return
-		} else {
-			workspace.Created = &now
-			workspace.Updated = &now
-			if len(workspace.Uuid) == 0 {
-				workspace.Uuid = xid.New().String()
-			}
-			workspace.Name = name
 		}
+
+		workspace.Created = &now
+		workspace.Updated = &now
+		if len(workspace.Uuid) == 0 {
+			workspace.Uuid = xid.New().String()
+		}
+	} else {
+		workspace.Updated = &now
+		workspace.Created = existing.Created
 	}
 
 	p, err := oh.db.CreateOrEditWorkspace(workspace)


### PR DESCRIPTION
### Problem:
I create a workspace, it automatically picks a random image. However, when I create a second, third, and subsequent workspaces, it displays a success message but updates the most recently created workspace again and again.
Because of the absence of the `UUID`.

![image](https://github.com/stakwork/sphinx-tribes/assets/87068339/7a3462ae-6584-4804-943c-8b415db9b77f)


## Describe your changes
- Cannot assign Workplace to Bounty because of the absence of the `UUID`.

### closes #563

## Issue ticket number and link:
- **Ticket Number:** [ 563 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/563 ]

### Evidence:
 Please see the attached video as evidence.
https://www.loom.com/share/6a31e086396f420a9433c2495beb1334

![image](https://github.com/stakwork/sphinx-tribes/assets/87068339/4bfb6eb0-6db4-41a7-91cd-8dda6145425f)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a video of changes in my PR