### PR TITLE
Feat: split up create and update person endpoint

### DIFF
--- a/routes/person.go
+++ b/routes/person.go
@@ -26,7 +26,8 @@ func PersonRoutes() chi.Router {
 	r.Group(func(r chi.Router) {
 		r.Use(auth.PubKeyContext)
 
-		r.Post("/", peopleHandler.CreateOrEditPerson)
+		r.Post("/", peopleHandler.CreatePerson)
+		r.Put("/", peopleHandler.UpdatePerson)
 		r.Delete("/{id}", peopleHandler.DeletePerson)
 	})
 	return r


### PR DESCRIPTION
## Describe your changes

This PR refactored the createOrEditPerson API business logic to perform only create user functionality, then created a new endpoint for updating people.

## Issue ticket number and link

Closes #1933 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox