### PR TITLE
Add Phase Tickets API: `Route`, `Handler`, and `Utility Function`

### DIFF
--- a/db/features.go
+++ b/db/features.go
@@ -327,3 +327,17 @@ func (db database) GetBountiesByPhaseUuid(phaseUuid string) []Bounty {
 	db.db.Model(&Bounty{}).Where("phase_uuid = ?", phaseUuid).Find(&bounties)
 	return bounties
 }
+
+func (db database) GetTicketsByPhase(featureUuid string, phaseUuid string) ([]Tickets, error) {
+	var tickets []Tickets
+
+	result := db.db.Where("feature_uuid = ? AND phase_uuid = ?", featureUuid, phaseUuid).
+		Order("sequence ASC").
+		Find(&tickets)
+
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to fetch tickets for phase: %w", result.Error)
+	}
+
+	return tickets, nil
+}

--- a/db/interface.go
+++ b/db/interface.go
@@ -198,4 +198,5 @@ type Database interface {
 	GetTicket(uuid string) (Tickets, error)
 	UpdateTicket(ticket Tickets) (Tickets, error)
 	DeleteTicket(uuid string) error
+	GetTicketsByPhase(featureUuid string, phaseUuid string) ([]Tickets, error)
 }

--- a/handlers/features_test.go
+++ b/handlers/features_test.go
@@ -1636,3 +1636,164 @@ func TestGetFeatureStories(t *testing.T) {
 		assert.Equal(t, http.StatusNotAcceptable, rr.Code)
 	})
 }
+
+func TestGetTickets(t *testing.T) {
+	teardownSuite := SetupSuite(t)
+	defer teardownSuite(t)
+
+	fHandler := NewFeatureHandler(db.TestDB)
+
+	person := db.Person{
+		Uuid:        uuid.New().String(),
+		OwnerAlias:  "test-alias",
+		UniqueName:  "test-unique-name",
+		OwnerPubKey: "test-pubkey",
+		PriceToMeet: 0,
+		Description: "test-description",
+	}
+	db.TestDB.CreateOrEditPerson(person)
+
+	workspace := db.Workspace{
+		Uuid:        uuid.New().String(),
+		Name:        "test-workspace" + uuid.New().String(),
+		OwnerPubKey: person.OwnerPubKey,
+		Github:      "https://github.com/test",
+		Website:     "https://www.testwebsite.com",
+		Description: "test-description",
+	}
+	db.TestDB.CreateOrEditWorkspace(workspace)
+
+	feature := db.WorkspaceFeatures{
+		Uuid:          uuid.New().String(),
+		WorkspaceUuid: workspace.Uuid,
+		Name:          "test-feature",
+		Url:           "https://github.com/test-feature",
+		Priority:      0,
+	}
+	db.TestDB.CreateOrEditFeature(feature)
+
+	featurePhase := db.FeaturePhase{
+		Uuid:        uuid.New().String(),
+		FeatureUuid: feature.Uuid,
+		Name:        "test-phase",
+		Priority:    0,
+	}
+	db.TestDB.CreateOrEditFeaturePhase(featurePhase)
+
+	ticket := db.Tickets{
+		UUID:        uuid.New(),
+		FeatureUUID: feature.Uuid,
+		PhaseUUID:   featurePhase.Uuid,
+		Name:        "Test Ticket",
+		Sequence:    1,
+		Description: "Test Description",
+		Status:      db.DraftTicket,
+	}
+
+	db.TestDB.UpdateTicket(ticket)
+
+	ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
+
+	t.Run("should return 401 if user is not authorized", func(t *testing.T) {
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", feature.Uuid)
+		rctx.URLParams.Add("phase_uuid", featurePhase.Uuid)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+			"/features/"+feature.Uuid+"/phase/"+featurePhase.Uuid+"/tickets", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		http.HandlerFunc(fHandler.GetTickets).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("should return 400 if feature UUID is invalid", func(t *testing.T) {
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", "invalid-uuid")
+		rctx.URLParams.Add("phase_uuid", featurePhase.Uuid)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/invalid-uuid/phase/"+featurePhase.Uuid+"/tickets", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		http.HandlerFunc(fHandler.GetTickets).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("should return 400 if phase UUID is invalid", func(t *testing.T) {
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", feature.Uuid)
+		rctx.URLParams.Add("phase_uuid", "invalid-uuid")
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+feature.Uuid+"/phase/invalid-uuid/tickets", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		http.HandlerFunc(fHandler.GetTickets).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("should return tickets successfully when authorized", func(t *testing.T) {
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", feature.Uuid)
+		rctx.URLParams.Add("phase_uuid", featurePhase.Uuid)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+feature.Uuid+"/phase/"+featurePhase.Uuid+"/tickets", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		http.HandlerFunc(fHandler.GetTickets).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var returnedTickets []db.Tickets
+		err = json.Unmarshal(rr.Body.Bytes(), &returnedTickets)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(returnedTickets))
+		assert.Equal(t, ticket.Name, returnedTickets[0].Name)
+		assert.Equal(t, ticket.Description, returnedTickets[0].Description)
+		assert.Equal(t, ticket.Status, returnedTickets[0].Status)
+		assert.Equal(t, ticket.Sequence, returnedTickets[0].Sequence)
+	})
+
+	t.Run("should return empty array when no tickets exist", func(t *testing.T) {
+
+		emptyPhase := db.FeaturePhase{
+			Uuid:        uuid.New().String(),
+			FeatureUuid: feature.Uuid,
+			Name:        "empty-phase",
+			Priority:    1,
+		}
+		db.TestDB.CreateOrEditFeaturePhase(emptyPhase)
+
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", feature.Uuid)
+		rctx.URLParams.Add("phase_uuid", emptyPhase.Uuid)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+feature.Uuid+"/phase/"+emptyPhase.Uuid+"/tickets", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		http.HandlerFunc(fHandler.GetTickets).ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var returnedTickets []db.Tickets
+		err = json.Unmarshal(rr.Body.Bytes(), &returnedTickets)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(returnedTickets))
+	})
+}

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -9440,3 +9440,58 @@ func NewDatabase(t interface {
 
 	return mock
 }
+
+// GetTicketsByPhase provides a mock function with given fields: featureUuid, phaseUuid
+func (_m *Database) GetTicketsByPhase(featureUuid string, phaseUuid string) ([]db.Tickets, error) {
+	ret := _m.Called(featureUuid, phaseUuid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTicketsByPhase")
+	}
+
+	var r0 []db.Tickets
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) ([]db.Tickets, error)); ok {
+		return rf(featureUuid, phaseUuid)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) []db.Tickets); ok {
+		r0 = rf(featureUuid, phaseUuid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.Tickets)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(featureUuid, phaseUuid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetTicketsByPhase_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) GetTicketsByPhase(featureUuid interface{}, phaseUuid interface{}) *Database_GetTicketsByPhase_Call {
+	return &Database_GetTicketsByPhase_Call{Call: _e.mock.On("GetTicketsByPhase", featureUuid, phaseUuid)}
+}
+
+func (_c *Database_GetTicketsByPhase_Call) Run(run func(featureUuid string, phaseUuid string)) *Database_GetTicketsByPhase_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Database_GetTicketsByPhase_Call) Return(_a0 []db.Tickets, _a1 error) *Database_GetTicketsByPhase_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetTicketsByPhase_Call) RunAndReturn(run func(string, string) ([]db.Tickets, error)) *Database_GetTicketsByPhase_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/routes/features.go
+++ b/routes/features.go
@@ -31,6 +31,7 @@ func FeatureRoutes() chi.Router {
 		r.Post("/phase", featureHandlers.CreateOrEditFeaturePhase)
 		r.Get("/{feature_uuid}/phase", featureHandlers.GetFeaturePhases)
 		r.Get("/{feature_uuid}/phase/{phase_uuid}", featureHandlers.GetFeaturePhaseByUUID)
+		r.Get("/{feature_uuid}/phase/{phase_uuid}/tickets", featureHandlers.GetTickets)
 		r.Delete("/{feature_uuid}/phase/{phase_uuid}", featureHandlers.DeleteFeaturePhase)
 
 		r.Post("/story", featureHandlers.CreateOrEditStory)


### PR DESCRIPTION
### Describe the changes:
- Implemented new API endpoint to fetch tickets by phase UUID, including route `/features/{uuid}/phase/{uuid}/tickets`, handler with authentication, and database utility function with comprehensive test coverage.

closes: #1982
closes: #1983
closes: #1984

## Issue ticket number and link:
- **Ticket Number:** [ 1982, 1983, 1984 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/1982, https://github.com/stakwork/sphinx-tribes-frontend/issues/1983, https://github.com/stakwork/sphinx-tribes-frontend/issues/1984 ]

### Evidence:

![image](https://github.com/user-attachments/assets/7aa5f313-419e-4d4a-a501-e86353a03321)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot of changes in my PR