### PR TITLE
Implement GET Endpoint for Phase-Specific Tickets

### DIFF
--- a/db/features.go
+++ b/db/features.go
@@ -327,3 +327,18 @@ func (db database) GetBountiesByPhaseUuid(phaseUuid string) []Bounty {
 	db.db.Model(&Bounty{}).Where("phase_uuid = ?", phaseUuid).Find(&bounties)
 	return bounties
 }
+
+func (db database) GetTicketsByPhaseUUID(featureUUID string, phaseUUID string) ([]Tickets, error) {
+	var tickets []Tickets
+
+	result := db.db.
+		Where("feature_uuid = ? AND phase_uuid = ?", featureUUID, phaseUUID).
+		Order("sequence ASC").
+		Find(&tickets)
+
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to fetch tickets: %w", result.Error)
+	}
+
+	return tickets, nil
+}

--- a/db/interface.go
+++ b/db/interface.go
@@ -198,4 +198,5 @@ type Database interface {
 	GetTicket(uuid string) (Tickets, error)
 	UpdateTicket(ticket Tickets) (Tickets, error)
 	DeleteTicket(uuid string) error
+	GetTicketsByPhaseUUID(featureUUID string, phaseUUID string) ([]Tickets, error)
 }

--- a/handlers/features.go
+++ b/handlers/features.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/go-chi/chi"
+	"github.com/google/uuid"
 	"github.com/rs/xid"
 	"github.com/stakwork/sphinx-tribes/auth"
 	"github.com/stakwork/sphinx-tribes/db"
@@ -696,4 +697,52 @@ func (oh *featureHandler) BriefSend(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(resp.StatusCode)
 	w.Write(respBody)
+}
+
+func (oh *featureHandler) GetTicketsByPhaseUUID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
+	if pubKeyFromAuth == "" {
+		fmt.Println("no pubkey from auth")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	featureUUID := chi.URLParam(r, "feature_uuid")
+	phaseUUID := chi.URLParam(r, "phase_uuid")
+
+	if _, err := uuid.Parse(featureUUID); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid feature UUID format"})
+		return
+	}
+	if _, err := uuid.Parse(phaseUUID); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid phase UUID format"})
+		return
+	}
+
+	feature := oh.db.GetFeatureByUuid(featureUUID)
+	if feature.Uuid == "" {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "feature not found"})
+		return
+	}
+
+	_, err := oh.db.GetFeaturePhaseByUuid(featureUUID, phaseUUID)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Phase not found"})
+		return
+	}
+
+	tickets, err := oh.db.GetTicketsByPhaseUUID(featureUUID, phaseUUID)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(tickets)
 }

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -9440,3 +9440,59 @@ func NewDatabase(t interface {
 
 	return mock
 }
+
+// GetTicketsByPhaseUUID provides a mock function with given fields: featureUUID, phaseUUID
+func (_m *Database) GetTicketsByPhaseUUID(featureUUID string, phaseUUID string) ([]db.Tickets, error) {
+    ret := _m.Called(featureUUID, phaseUUID)
+
+    if len(ret) == 0 {
+        panic("no return value specified for GetTicketsByPhaseUUID")
+    }
+
+    var r0 []db.Tickets
+    var r1 error
+    if rf, ok := ret.Get(0).(func(string, string) ([]db.Tickets, error)); ok {
+        return rf(featureUUID, phaseUUID)
+    }
+    if rf, ok := ret.Get(0).(func(string, string) []db.Tickets); ok {
+        r0 = rf(featureUUID, phaseUUID)
+    } else {
+        if ret.Get(0) != nil {
+            r0 = ret.Get(0).([]db.Tickets)
+        }
+    }
+
+    if rf, ok := ret.Get(1).(func(string, string) error); ok {
+        r1 = rf(featureUUID, phaseUUID)
+    } else {
+        r1 = ret.Error(1)
+    }
+
+    return r0, r1
+}
+
+type Database_GetTicketsByPhaseUUID_Call struct {
+    *mock.Call
+}
+
+
+func (_e *Database_Expecter) GetTicketsByPhaseUUID(featureUUID interface{}, phaseUUID interface{}) *Database_GetTicketsByPhaseUUID_Call {
+    return &Database_GetTicketsByPhaseUUID_Call{Call: _e.mock.On("GetTicketsByPhaseUUID", featureUUID, phaseUUID)}
+}
+
+func (_c *Database_GetTicketsByPhaseUUID_Call) Run(run func(featureUUID string, phaseUUID string)) *Database_GetTicketsByPhaseUUID_Call {
+    _c.Call.Run(func(args mock.Arguments) {
+        run(args[0].(string), args[1].(string))
+    })
+    return _c
+}
+
+func (_c *Database_GetTicketsByPhaseUUID_Call) Return(_a0 []db.Tickets, _a1 error) *Database_GetTicketsByPhaseUUID_Call {
+    _c.Call.Return(_a0, _a1)
+    return _c
+}
+
+func (_c *Database_GetTicketsByPhaseUUID_Call) RunAndReturn(run func(string, string) ([]db.Tickets, error)) *Database_GetTicketsByPhaseUUID_Call {
+    _c.Call.Return(run)
+    return _c
+}

--- a/routes/features.go
+++ b/routes/features.go
@@ -39,6 +39,7 @@ func FeatureRoutes() chi.Router {
 		r.Get("/{feature_uuid}/story/{story_uuid}", featureHandlers.GetStoryByUuid)
 		r.Delete("/{feature_uuid}/story/{story_uuid}", featureHandlers.DeleteStory)
 		r.Get("/{feature_uuid}/phase/{phase_uuid}/bounty", featureHandlers.GetBountiesByFeatureAndPhaseUuid)
+		r.Get("/{feature_uuid}/phase/{phase_uuid}/tickets", featureHandlers.GetTicketsByPhaseUUID)
 		r.Get("/{feature_uuid}/phase/{phase_uuid}/bounty/count", featureHandlers.GetBountiesCountByFeatureAndPhaseUuid)
 
 	})


### PR DESCRIPTION
### Describe the chnages:
- Adds new GET endpoint to retrieve tickets by phase UUID with authentication, validation, and comprehensive test coverage

closes: #1972

## Issue ticket number and link:
- **Ticket Number:** [ 1972 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/1972 ]

### Evidence:

![image](https://github.com/user-attachments/assets/1359f6f2-fac0-454d-a6cb-3874160d5de7)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot of changes in my PR