### PR TITLE
push to posthog and compress function calls to hex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/lightningnetwork/lnd/tlv v1.1.1 // indirect
 	github.com/lightningnetwork/lnd/tor v1.1.2 // indirect
 	github.com/onsi/gomega v1.26.0 // indirect
+	github.com/posthog/posthog-go v1.2.24 // indirect
 	github.com/robfig/cron v1.2.0
 	github.com/urfave/negroni v1.0.0 // indirect
 	github.com/xhd2015/xgo/runtime v1.0.52 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2028,6 +2028,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/posthog/posthog-go v1.2.24 h1:A+iG4saBJemo++VDlcWovbYf8KFFNUfrCoJtsc40RPA=
+github.com/posthog/posthog-go v1.2.24/go.mod h1:uYC2l1Yktc8E+9FAHJ9QZG4vQf/NHJPD800Hsm7DzoM=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/routes/index.go
+++ b/routes/index.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"compress/gzip"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -26,6 +28,8 @@ import (
 	"github.com/stakwork/sphinx-tribes/logger"
 	customMiddleware "github.com/stakwork/sphinx-tribes/middlewares"
 	"github.com/stakwork/sphinx-tribes/utils"
+
+	"github.com/posthog/posthog-go"
 )
 
 // NewRouter creates a chi router
@@ -196,11 +200,36 @@ func sendEdgeListToJarvis(edgeList utils.EdgeList) error {
 	return fmt.Errorf("jarvis returned non-success status: %d, body: %s", resp.StatusCode, string(body))
 }
 
+func compressToHex(input string) (string, error) {
+	// Create a buffer to hold the compressed data
+	var compressedBuffer bytes.Buffer
+
+	// Create a gzip writer
+	gzipWriter := gzip.NewWriter(&compressedBuffer)
+
+	// Write the input string to the gzip writer
+	_, err := gzipWriter.Write([]byte(input))
+	if err != nil {
+		return "", fmt.Errorf("failed to write to gzip writer: %w", err)
+	}
+
+	// Close the gzip writer to flush the data
+	err = gzipWriter.Close()
+	if err != nil {
+		return "", fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	// Encode the compressed data to hex
+	hexEncoded := hex.EncodeToString(compressedBuffer.Bytes())
+	return hexEncoded, nil
+}
+
 // Middleware to handle InternalServerError
 func internalServerErrorHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rr := negroni.NewResponseWriter(w)
 
+		elements_chain := ""
 		trap.AddInterceptor(&trap.Interceptor{
 			Pre: func(ctx context.Context, f *core.FuncInfo, args core.Object, results core.Object) (interface{}, error) {
 				index := strings.Index(f.File, "sphinx-tribes")
@@ -208,11 +237,40 @@ func internalServerErrorHandler(next http.Handler) http.Handler {
 				if index != -1 {
 					trimmed = f.File[index:]
 				}
-				logger.Log.Machine("%s:%d %s\n", trimmed, f.Line, f.Name)
+				//fmt.Printf("%s:%d %s\n", trimmed, f.Line, f.Name)
+				append_element := fmt.Sprintf("%s:%d %s,\n", trimmed, f.Line, f.Name)
+				elements_chain = fmt.Sprintf("%s%s", append_element, elements_chain)
 
 				return nil, nil
 			},
 		})
+
+		defer func() {
+			posthog_key := os.Getenv("POSTHOG_KEY")
+			posthog_url := os.Getenv("POSTHOG_URL")
+			session_id := r.Header.Get("x-session-id")
+			if posthog_key != "" && posthog_url != "" && session_id != "" {
+				logger.Log.Info("Sending to Posthog")
+				client, _ := posthog.NewWithConfig(
+					posthog_key,
+					posthog.Config{
+						Endpoint: posthog_url,
+					},
+				)
+				defer client.Close()
+				hexCompressed, _ := compressToHex(elements_chain)
+				_ = client.Enqueue(posthog.Capture{
+					DistinctId: session_id,         // Unique ID for the user
+					Event:      "backend_api_call", // The event name
+					Properties: map[string]interface{}{
+						"$session_id":     session_id,
+						"$event_type":     "backend_api_call",
+						"$elements_chain": hexCompressed,
+					},
+				})
+			}
+		}()
+
 		defer func() {
 			if err := recover(); err != nil {
 				// Get stack trace


### PR DESCRIPTION
## Describe your changes
What this change does is takes the function calls from xgo on a specific api call and then compresses it to hex to then send to posthog

We must compress to hex because otherwise the size is too large for posthog to accept

We may need to rework this a bit when we have variables logged aswell because then the hex string might go over the size of what posthog accepts