### PR TITLE
Feature: Add metadata fields to Feature Phases (Purpose, Outcome, Scope)

### DIFF
--- a/db/features.go
+++ b/db/features.go
@@ -88,6 +88,16 @@ func (db database) DeleteFeatureByUuid(uuid string) error {
 func (db database) CreateOrEditFeaturePhase(phase FeaturePhase) (FeaturePhase, error) {
 	phase.Name = strings.TrimSpace(phase.Name)
 
+	if phase.PhasePurpose != "" {
+		phase.PhasePurpose = strings.TrimSpace(phase.PhasePurpose)
+	}
+	if phase.PhaseOutcome != "" {
+		phase.PhaseOutcome = strings.TrimSpace(phase.PhaseOutcome)
+	}
+	if phase.PhaseScope != "" {
+		phase.PhaseScope = strings.TrimSpace(phase.PhaseScope)
+	}
+
 	now := time.Now()
 	phase.Updated = &now
 
@@ -116,10 +126,25 @@ func (db database) GetPhasesByFeatureUuid(featureUuid string) []FeaturePhase {
 
 func (db database) GetFeaturePhaseByUuid(featureUuid, phaseUuid string) (FeaturePhase, error) {
 	phase := FeaturePhase{}
-	result := db.db.Model(&FeaturePhase{}).Where("feature_uuid = ? AND uuid = ?", featureUuid, phaseUuid).First(&phase)
+	result := db.db.Model(&FeaturePhase{}).
+		Where("feature_uuid = ? AND uuid = ?", featureUuid, phaseUuid).
+		First(&phase)
+
 	if result.RowsAffected == 0 {
 		return phase, errors.New("no phase found")
 	}
+
+	phase.Name = strings.TrimSpace(phase.Name)
+	if phase.PhasePurpose != "" {
+		phase.PhasePurpose = strings.TrimSpace(phase.PhasePurpose)
+	}
+	if phase.PhaseOutcome != "" {
+		phase.PhaseOutcome = strings.TrimSpace(phase.PhaseOutcome)
+	}
+	if phase.PhaseScope != "" {
+		phase.PhaseScope = strings.TrimSpace(phase.PhaseScope)
+	}
+
 	return phase, nil
 }
 

--- a/db/structs.go
+++ b/db/structs.go
@@ -619,14 +619,17 @@ type WorkspaceFeatures struct {
 }
 
 type FeaturePhase struct {
-	Uuid        string     `json:"uuid" gorm:"primary_key"`
-	FeatureUuid string     `json:"feature_uuid"`
-	Name        string     `json:"name"`
-	Priority    int        `json:"priority"`
-	Created     *time.Time `json:"created"`
-	Updated     *time.Time `json:"updated"`
-	CreatedBy   string     `json:"created_by"`
-	UpdatedBy   string     `json:"updated_by"`
+	Uuid         string     `json:"uuid" gorm:"primary_key"`
+	FeatureUuid  string     `json:"feature_uuid"`
+	Name         string     `json:"name"`
+	Priority     int        `json:"priority"`
+	PhasePurpose string     `json:"phase_purpose,omitempty" gorm:"default:null"`
+	PhaseOutcome string     `json:"phase_outcome,omitempty" gorm:"default:null"`
+	PhaseScope   string     `json:"phase_scope,omitempty" gorm:"default:null"`
+	Created      *time.Time `json:"created"`
+	Updated      *time.Time `json:"updated"`
+	CreatedBy    string     `json:"created_by"`
+	UpdatedBy    string     `json:"updated_by"`
 }
 
 type BountyRoles struct {


### PR DESCRIPTION
### Describe the Changes:
- Add optional metadata fields (purpose, outcome, scope) to feature phases for better phase documentation and tracking.

Daily Bounty: https://community.sphinx.chat/bounty/3280

## Issue ticket number and link:
- **Bounty Number:** [ 3280 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3280](url) ]

### Evidence:

https://www.loom.com/share/878554e31ee54111835b6d9008baff49

![image](https://github.com/user-attachments/assets/c0b35b6e-6fce-466b-9fc7-04d6d5a24e6d)

![image](https://github.com/user-attachments/assets/45c1f5fc-f2e7-413f-b5d9-8578ca6c3b5c)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR