### PR TITLE
Feature: Enhanced Bounty Card Response with Assignee Details

### DIFF
--- a/db/structs.go
+++ b/db/structs.go
@@ -951,13 +951,15 @@ const (
 )
 
 type BountyCard struct {
-	BountyID    uint              `json:"id"`
-	Title       string            `json:"title"`
-	AssigneePic string            `json:"assignee_img,omitempty"`
-	Features    WorkspaceFeatures `json:"features"`
-	Phase       FeaturePhase      `json:"phase"`
-	Workspace   Workspace         `json:"workspace"`
-	Status      BountyStatus      `json:"status"`
+	BountyID     uint              `json:"id"`
+	Title        string            `json:"title"`
+	AssigneePic  string            `json:"assignee_img,omitempty"`
+	Assignee     string            `json:"assignee"`
+	AssigneeName string            `json:"assignee_name"`
+	Features     WorkspaceFeatures `json:"features"`
+	Phase        FeaturePhase      `json:"phase"`
+	Workspace    Workspace         `json:"workspace"`
+	Status       BountyStatus      `json:"status"`
 }
 
 type WfRequestStatus string

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -1550,7 +1550,16 @@ func (h *bountyHandler) GenerateBountyCardResponse(bounties []db.NewBounty) []db
 	for i := 0; i < len(bounties); i++ {
 		bounty := bounties[i]
 
-		assignee := h.db.GetPersonByPubkey(bounty.Assignee)
+		var assigneePic, assigneeName, assigneePubkey string
+		if bounty.Assignee != "" {
+			assignee := h.db.GetPersonByPubkey(bounty.Assignee)
+			if assignee.OwnerPubKey != "" {
+				assigneePic = assignee.Img
+				assigneeName = assignee.OwnerAlias
+				assigneePubkey = assignee.OwnerPubKey
+			}
+		}
+
 		workspace := h.db.GetWorkspaceByUuid(bounty.WorkspaceUuid)
 
 		var phase db.FeaturePhase
@@ -1567,13 +1576,15 @@ func (h *bountyHandler) GenerateBountyCardResponse(bounties []db.NewBounty) []db
 		status := calculateBountyStatus(bounty)
 
 		b := db.BountyCard{
-			BountyID:    bounty.ID,
-			Title:       bounty.Title,
-			AssigneePic: assignee.Img,
-			Features:    feature,
-			Phase:       phase,
-			Workspace:   workspace,
-			Status:      status,
+			BountyID:     bounty.ID,
+			Title:        bounty.Title,
+			AssigneePic:  assigneePic,
+			Assignee:     assigneePubkey,
+			AssigneeName: assigneeName,
+			Features:     feature,
+			Phase:        phase,
+			Workspace:    workspace,
+			Status:       status,
 		}
 
 		bountyCardResponse = append(bountyCardResponse, b)


### PR DESCRIPTION
### Describe the Changes:
- added Bounty Card Response with Assignee Details

Daily Bounty: https://community.sphinx.chat/bounty/3305

## Issue ticket number and link:
- **Bounty Number:** [ 3305 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3305](url) ]

### Evidence:

#### `Loom`

https://www.loom.com/share/ab6b1c347e564309bce7cbfea01e7a15

![image](https://github.com/user-attachments/assets/df24e2f6-aec9-4e20-9c0d-bd3a0f938452)

![image](https://github.com/user-attachments/assets/9fc8a96a-d879-4764-a749-a89347845bac)

#### `Unit Test`

![image](https://github.com/user-attachments/assets/eae1deab-7500-4be4-a0f1-781408ec5949)

![image](https://github.com/user-attachments/assets/2f70bb8f-6245-41a9-a751-319cdc39e1c1)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR