### PR TITLE
ws id fallbacks

### DIFF
--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/stakwork/sphinx-tribes/config"
+	"github.com/stakwork/sphinx-tribes/utils"
 )
 
 var WebsocketPool = NewPool()
@@ -35,8 +36,14 @@ func Upgrade(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {
 }
 
 func ServeWs(pool *Pool, w http.ResponseWriter, r *http.Request) { // get url query params
+
+	// get url query params
 	queryParams := r.URL.Query()
 	uniqueId := queryParams.Get("uniqueId")
+	if uniqueId == "" || uniqueId == "null" || uniqueId == "undefined" {
+		// or random
+		uniqueId = utils.GetRandomToken(40)
+	}
 
 	conn, err := Upgrade(w, r)
 	if err != nil {


### PR DESCRIPTION
use uniqueId from frontend for WS id. But check for empty string, `null` or `undefined`, and generate a random unique id if needed