### PR TITLE
Feature: Add Notification Database Layer with CRUD Operations And Unit Test

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -93,6 +93,7 @@ func InitDB() {
 	db.AutoMigrate(&FeatureFlag{})
 	db.AutoMigrate(&Endpoint{})
 	db.AutoMigrate(&FeaturedBounty{})
+	db.AutoMigrate(&Notification{})
 
 	DB.MigrateTablesWithOrgUuid()
 	DB.MigrateOrganizationToWorkspace()

--- a/db/interface.go
+++ b/db/interface.go
@@ -254,4 +254,13 @@ type Database interface {
 	CreateFeaturedBounty(bounty FeaturedBounty) error
 	UpdateFeaturedBounty(bountyID string, bounty FeaturedBounty) error
 	DeleteFeaturedBounty(bountyID string) error
+	CreateNotification(n *Notification) error
+	GetNotification(uuid string) (*Notification, error)
+	UpdateNotification(uuid string, updates map[string]interface{}) error
+	DeleteNotification(uuid string) error
+	GetPendingNotifications() ([]Notification, error)
+	GetFailedNotifications(maxRetries int) ([]Notification, error)
+	GetNotificationsByPubKey(pubKey string, limit, offset int) ([]Notification, error)
+	IncrementRetryCount(uuid string) error
+	GetNotificationCount(pubKey string) (int64, error)
 }

--- a/db/notifications.go
+++ b/db/notifications.go
@@ -1,0 +1,167 @@
+package db
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrMissingEvent   = errors.New("event is required")
+	ErrMissingPubKey  = errors.New("pub_key is required")
+	ErrMissingContent = errors.New("content is required")
+	ErrMissingUUID    = errors.New("uuid is required")
+)
+
+func (db database) CreateNotification(n *Notification) error {
+
+	if n.Event == "" {
+		return ErrMissingEvent
+	}
+	if n.PubKey == "" {
+		return ErrMissingPubKey
+	}
+	if n.Content == "" {
+		return ErrMissingContent
+	}
+
+	if n.UUID == "" {
+		n.UUID = uuid.New().String()
+	}
+
+	now := time.Now()
+	n.CreatedAt = &now
+	n.UpdatedAt = &now
+
+	if n.Status == "" {
+		n.Status = NotificationStatusPending
+	}
+
+	return db.db.Create(n).Error
+}
+
+func (db database) GetNotification(uuid string) (*Notification, error) {
+	if uuid == "" {
+		return nil, ErrMissingUUID
+	}
+
+	var notification Notification
+	err := db.db.Where("uuid = ?", uuid).First(&notification).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &notification, err
+}
+
+func (db database) UpdateNotification(uuid string, updates map[string]interface{}) error {
+	if uuid == "" {
+		return ErrMissingUUID
+	}
+
+	if event, ok := updates["event"].(string); ok && event == "" {
+		return ErrMissingEvent
+	}
+	if pubKey, ok := updates["pub_key"].(string); ok && pubKey == "" {
+		return ErrMissingPubKey
+	}
+	if content, ok := updates["content"].(string); ok && content == "" {
+		return ErrMissingContent
+	}
+
+	updates["updated_at"] = time.Now()
+	result := db.db.Model(&Notification{}).Where("uuid = ?", uuid).Updates(updates)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+func (db database) DeleteNotification(uuid string) error {
+	if uuid == "" {
+		return ErrMissingUUID
+	}
+
+	result := db.db.Where("uuid = ?", uuid).Delete(&Notification{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+func (db database) GetPendingNotifications() ([]Notification, error) {
+	var notifications []Notification
+	err := db.db.Where("status = ?", NotificationStatusPending).Find(&notifications).Error
+	return notifications, err
+}
+
+func (db database) GetFailedNotifications(maxRetries int) ([]Notification, error) {
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+
+	var notifications []Notification
+	err := db.db.Where("status = ? AND retries < ?", NotificationStatusFailed, maxRetries).Find(&notifications).Error
+	return notifications, err
+}
+
+func (db database) GetNotificationsByPubKey(pubKey string, limit, offset int) ([]Notification, error) {
+	if pubKey == "" {
+		return nil, ErrMissingPubKey
+	}
+
+	if limit < 0 {
+		limit = 0
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var notifications []Notification
+	query := db.db.Where("pub_key = ?", pubKey)
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if offset > 0 {
+		query = query.Offset(offset)
+	}
+
+	err := query.Order("created_at DESC").Find(&notifications).Error
+	return notifications, err
+}
+
+func (db database) IncrementRetryCount(uuid string) error {
+	if uuid == "" {
+		return ErrMissingUUID
+	}
+
+	result := db.db.Model(&Notification{}).
+		Where("uuid = ?", uuid).
+		UpdateColumn("retries", gorm.Expr("retries + 1"))
+
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+func (db database) GetNotificationCount(pubKey string) (int64, error) {
+	if pubKey == "" {
+		return 0, ErrMissingPubKey
+	}
+
+	var count int64
+	err := db.db.Model(&Notification{}).Where("pub_key = ?", pubKey).Count(&count).Error
+	return count, err
+}

--- a/db/notifications_test.go
+++ b/db/notifications_test.go
@@ -1,0 +1,511 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func TestNotificationCRUD(t *testing.T) {
+	InitTestDB()
+	defer CloseTestDB()
+
+	cleanup := func() {
+		TestDB.db.Exec("DELETE FROM notifications")
+	}
+
+	t.Run("CreateNotification", func(t *testing.T) {
+		defer cleanup()
+
+		tests := []struct {
+			name         string
+			notification *Notification
+			expectError  error
+		}{
+			{
+				name: "Valid Notification",
+				notification: &Notification{
+					Event:   "test_event",
+					PubKey:  "test_pubkey",
+					Content: "test_content",
+				},
+				expectError: nil,
+			},
+			{
+				name: "Missing Event",
+				notification: &Notification{
+					PubKey:  "test_pubkey",
+					Content: "test_content",
+				},
+				expectError: ErrMissingEvent,
+			},
+			{
+				name: "Missing PubKey",
+				notification: &Notification{
+					Event:   "test_event",
+					Content: "test_content",
+				},
+				expectError: ErrMissingPubKey,
+			},
+			{
+				name: "Missing Content",
+				notification: &Notification{
+					Event:  "test_event",
+					PubKey: "test_pubkey",
+				},
+				expectError: ErrMissingContent,
+			},
+			{
+				name: "With Custom UUID",
+				notification: &Notification{
+					UUID:    uuid.New().String(),
+					Event:   "test_event",
+					PubKey:  "test_pubkey",
+					Content: "test_content",
+				},
+				expectError: nil,
+			},
+			{
+				name: "With Custom Status",
+				notification: &Notification{
+					Event:   "test_event",
+					PubKey:  "test_pubkey",
+					Content: "test_content",
+					Status:  NotificationStatusComplete,
+				},
+				expectError: nil,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := TestDB.CreateNotification(tt.notification)
+				assert.Equal(t, tt.expectError, err)
+
+				if err == nil {
+					assert.NotEmpty(t, tt.notification.UUID)
+					assert.NotNil(t, tt.notification.CreatedAt)
+					assert.NotNil(t, tt.notification.UpdatedAt)
+					if tt.notification.Status == "" {
+						assert.Equal(t, NotificationStatusPending, tt.notification.Status)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("GetNotification", func(t *testing.T) {
+		defer cleanup()
+
+		testNotif := &Notification{
+			Event:   "test_event",
+			PubKey:  "test_pubkey",
+			Content: "test_content",
+		}
+		err := TestDB.CreateNotification(testNotif)
+		assert.NoError(t, err)
+
+		tests := []struct {
+			name        string
+			uuid        string
+			expectError error
+			expectNil   bool
+		}{
+			{
+				name:        "Valid UUID",
+				uuid:        testNotif.UUID,
+				expectError: nil,
+				expectNil:   false,
+			},
+			{
+				name:        "Empty UUID",
+				uuid:        "",
+				expectError: ErrMissingUUID,
+				expectNil:   true,
+			},
+			{
+				name:        "Non-existent UUID",
+				uuid:        uuid.New().String(),
+				expectError: nil,
+				expectNil:   true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				notification, err := TestDB.GetNotification(tt.uuid)
+				assert.Equal(t, tt.expectError, err)
+				if tt.expectNil {
+					assert.Nil(t, notification)
+				} else {
+					assert.NotNil(t, notification)
+					assert.Equal(t, testNotif.UUID, notification.UUID)
+				}
+			})
+		}
+	})
+
+	t.Run("UpdateNotification", func(t *testing.T) {
+		defer cleanup()
+
+		testNotif := &Notification{
+			Event:   "test_event",
+			PubKey:  "test_pubkey",
+			Content: "test_content",
+		}
+		err := TestDB.CreateNotification(testNotif)
+		assert.NoError(t, err)
+
+		tests := []struct {
+			name        string
+			uuid        string
+			updates     map[string]interface{}
+			expectError error
+		}{
+			{
+				name: "Valid Update",
+				uuid: testNotif.UUID,
+				updates: map[string]interface{}{
+					"content": "updated_content",
+				},
+				expectError: nil,
+			},
+			{
+				name:        "Empty UUID",
+				uuid:        "",
+				updates:     map[string]interface{}{},
+				expectError: ErrMissingUUID,
+			},
+			{
+				name: "Empty Event",
+				uuid: testNotif.UUID,
+				updates: map[string]interface{}{
+					"event": "",
+				},
+				expectError: ErrMissingEvent,
+			},
+			{
+				name: "Empty PubKey",
+				uuid: testNotif.UUID,
+				updates: map[string]interface{}{
+					"pub_key": "",
+				},
+				expectError: ErrMissingPubKey,
+			},
+			{
+				name: "Empty Content",
+				uuid: testNotif.UUID,
+				updates: map[string]interface{}{
+					"content": "",
+				},
+				expectError: ErrMissingContent,
+			},
+			{
+				name:        "Non-existent UUID",
+				uuid:        uuid.New().String(),
+				updates:     map[string]interface{}{},
+				expectError: gorm.ErrRecordNotFound,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := TestDB.UpdateNotification(tt.uuid, tt.updates)
+				assert.Equal(t, tt.expectError, err)
+			})
+		}
+	})
+
+	t.Run("DeleteNotification", func(t *testing.T) {
+		defer cleanup()
+
+		testNotif := &Notification{
+			Event:   "test_event",
+			PubKey:  "test_pubkey",
+			Content: "test_content",
+		}
+		err := TestDB.CreateNotification(testNotif)
+		assert.NoError(t, err)
+
+		tests := []struct {
+			name        string
+			uuid        string
+			expectError error
+		}{
+			{
+				name:        "Valid UUID",
+				uuid:        testNotif.UUID,
+				expectError: nil,
+			},
+			{
+				name:        "Empty UUID",
+				uuid:        "",
+				expectError: ErrMissingUUID,
+			},
+			{
+				name:        "Non-existent UUID",
+				uuid:        uuid.New().String(),
+				expectError: gorm.ErrRecordNotFound,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := TestDB.DeleteNotification(tt.uuid)
+				assert.Equal(t, tt.expectError, err)
+			})
+		}
+	})
+
+	t.Run("GetPendingNotifications", func(t *testing.T) {
+		defer cleanup()
+
+		notifications := []*Notification{
+			{Event: "event1", PubKey: "key1", Content: "content1", Status: NotificationStatusPending},
+			{Event: "event2", PubKey: "key2", Content: "content2", Status: NotificationStatusComplete},
+			{Event: "event3", PubKey: "key3", Content: "content3", Status: NotificationStatusPending},
+		}
+
+		for _, n := range notifications {
+			err := TestDB.CreateNotification(n)
+			assert.NoError(t, err)
+		}
+
+		result, err := TestDB.GetPendingNotifications()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(result))
+		for _, n := range result {
+			assert.Equal(t, NotificationStatusPending, n.Status)
+		}
+	})
+
+	t.Run("GetFailedNotifications", func(t *testing.T) {
+		defer cleanup()
+
+		notifications := []*Notification{
+			{Event: "event1", PubKey: "key1", Content: "content1", Status: NotificationStatusFailed, Retries: 1},
+			{Event: "event2", PubKey: "key2", Content: "content2", Status: NotificationStatusFailed, Retries: 2},
+			{Event: "event3", PubKey: "key3", Content: "content3", Status: NotificationStatusFailed, Retries: 3},
+		}
+
+		for _, n := range notifications {
+			err := TestDB.CreateNotification(n)
+			assert.NoError(t, err)
+		}
+
+		tests := []struct {
+			name          string
+			maxRetries    int
+			expectedCount int
+		}{
+			{
+				name:          "Max Retries 0",
+				maxRetries:    0,
+				expectedCount: 0,
+			},
+			{
+				name:          "Negative Max Retries",
+				maxRetries:    -1,
+				expectedCount: 0,
+			},
+			{
+				name:          "Max Retries 5",
+				maxRetries:    5,
+				expectedCount: 3,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := TestDB.GetFailedNotifications(tt.maxRetries)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedCount, len(result))
+			})
+		}
+	})
+
+	t.Run("GetNotificationsByPubKey", func(t *testing.T) {
+		defer cleanup()
+
+		pubKey := "test_key"
+		notifications := []*Notification{
+			{Event: "event1", PubKey: pubKey, Content: "content1"},
+			{Event: "event2", PubKey: pubKey, Content: "content2"},
+			{Event: "event3", PubKey: "other_key", Content: "content3"},
+		}
+
+		for _, n := range notifications {
+			err := TestDB.CreateNotification(n)
+			assert.NoError(t, err)
+		}
+
+		tests := []struct {
+			name          string
+			pubKey        string
+			limit         int
+			offset        int
+			expectedCount int
+			expectError   error
+		}{
+			{
+				name:          "Valid PubKey",
+				pubKey:        pubKey,
+				limit:         10,
+				offset:        0,
+				expectedCount: 2,
+				expectError:   nil,
+			},
+			{
+				name:          "Empty PubKey",
+				pubKey:        "",
+				limit:         10,
+				offset:        0,
+				expectedCount: 0,
+				expectError:   ErrMissingPubKey,
+			},
+			{
+				name:          "With Limit",
+				pubKey:        pubKey,
+				limit:         1,
+				offset:        0,
+				expectedCount: 1,
+				expectError:   nil,
+			},
+			{
+				name:          "With Offset",
+				pubKey:        pubKey,
+				limit:         10,
+				offset:        1,
+				expectedCount: 1,
+				expectError:   nil,
+			},
+			{
+				name:          "Negative Limit",
+				pubKey:        pubKey,
+				limit:         -1,
+				offset:        0,
+				expectedCount: 2,
+				expectError:   nil,
+			},
+			{
+				name:          "Negative Offset",
+				pubKey:        pubKey,
+				limit:         10,
+				offset:        -1,
+				expectedCount: 2,
+				expectError:   nil,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := TestDB.GetNotificationsByPubKey(tt.pubKey, tt.limit, tt.offset)
+				assert.Equal(t, tt.expectError, err)
+				if err == nil {
+					assert.Equal(t, tt.expectedCount, len(result))
+				}
+			})
+		}
+	})
+
+	t.Run("IncrementRetryCount", func(t *testing.T) {
+		defer cleanup()
+
+		testNotif := &Notification{
+			Event:   "test_event",
+			PubKey:  "test_pubkey",
+			Content: "test_content",
+			Retries: 0,
+		}
+		err := TestDB.CreateNotification(testNotif)
+		assert.NoError(t, err)
+
+		tests := []struct {
+			name        string
+			uuid        string
+			expectError error
+		}{
+			{
+				name:        "Valid UUID",
+				uuid:        testNotif.UUID,
+				expectError: nil,
+			},
+			{
+				name:        "Empty UUID",
+				uuid:        "",
+				expectError: ErrMissingUUID,
+			},
+			{
+				name:        "Non-existent UUID",
+				uuid:        uuid.New().String(),
+				expectError: gorm.ErrRecordNotFound,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := TestDB.IncrementRetryCount(tt.uuid)
+				assert.Equal(t, tt.expectError, err)
+
+				if err == nil {
+					notification, _ := TestDB.GetNotification(tt.uuid)
+					assert.Equal(t, testNotif.Retries+1, notification.Retries)
+				}
+			})
+		}
+	})
+
+	t.Run("GetNotificationCount", func(t *testing.T) {
+		defer cleanup()
+
+		pubKey := "test_key"
+		notifications := []*Notification{
+			{Event: "event1", PubKey: pubKey, Content: "content1"},
+			{Event: "event2", PubKey: pubKey, Content: "content2"},
+			{Event: "event3", PubKey: "other_key", Content: "content3"},
+		}
+
+		for _, n := range notifications {
+			err := TestDB.CreateNotification(n)
+			assert.NoError(t, err)
+		}
+
+		tests := []struct {
+			name          string
+			pubKey        string
+			expectedCount int64
+			expectError   error
+		}{
+			{
+				name:          "Valid PubKey",
+				pubKey:        pubKey,
+				expectedCount: 2,
+				expectError:   nil,
+			},
+			{
+				name:          "Empty PubKey",
+				pubKey:        "",
+				expectedCount: 0,
+				expectError:   ErrMissingPubKey,
+			},
+			{
+				name:          "Non-existent PubKey",
+				pubKey:        "non_existent",
+				expectedCount: 0,
+				expectError:   nil,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				count, err := TestDB.GetNotificationCount(tt.pubKey)
+				assert.Equal(t, tt.expectError, err)
+				if err == nil {
+					assert.Equal(t, tt.expectedCount, count)
+				}
+			})
+		}
+	})
+}

--- a/db/structs.go
+++ b/db/structs.go
@@ -1181,6 +1181,27 @@ type FeaturedBounty struct {
 	UpdatedAt time.Time `json:"updated_at" gorm:"default:current_timestamp"`
 }
 
+type NotificationStatus string
+
+const (
+	NotificationStatusPending            NotificationStatus = "PENDING"
+	NotificationStatusComplete           NotificationStatus = "COMPLETE"
+	NotificationStatusFailed             NotificationStatus = "FAILED"
+	NotificationStatusWaitingKeyExchange NotificationStatus = "WAITING_KEY_EXCHANGE"
+)
+
+type Notification struct {
+	ID        uint               `json:"id" gorm:"primaryKey;autoIncrement"`
+	UUID      string             `json:"uuid" gorm:"type:uuid;uniqueIndex;not null"`
+	Event     string             `json:"event" gorm:"type:varchar(50);not null"`
+	PubKey    string             `json:"pub_key" gorm:"type:varchar(100);not null;index"`
+	Content   string             `json:"content" gorm:"type:text;not null"`
+	Retries   int                `json:"retries" gorm:"default:0"`
+	Status    NotificationStatus `json:"status" gorm:"type:varchar(20);default:'PENDING'"`
+	CreatedAt *time.Time         `json:"created_at" gorm:"default:current_timestamp"`
+	UpdatedAt *time.Time         `json:"updated_at" gorm:"default:current_timestamp"`
+}
+
 func (Person) TableName() string {
 	return "people"
 }

--- a/db/test_config.go
+++ b/db/test_config.go
@@ -67,6 +67,7 @@ func InitTestDB() {
 	db.AutoMigrate(&WorkspaceCodeGraph{})
 	db.AutoMigrate(&FeatureFlag{})
 	db.AutoMigrate(&Bounty{})
+	db.AutoMigrate(&Notification{})
 
 	people := TestDB.GetAllPeople()
 	for _, p := range people {

--- a/handlers/bounties_test.go
+++ b/handlers/bounties_test.go
@@ -514,7 +514,7 @@ func TestGetWantedsHeader(t *testing.T) {
 			},
 		},
 		{
-			name: "Large Number of Developers and Bounties",
+			name: "Large Number oDevelopers and Bounties",
 			setupTestData: func(t *testing.T) {
 
 				for i := 1; i <= 500; i++ {

--- a/handlers/bounties_test.go
+++ b/handlers/bounties_test.go
@@ -517,7 +517,7 @@ func TestGetWantedsHeader(t *testing.T) {
 			name: "Large Number of Developers and Bounties",
 			setupTestData: func(t *testing.T) {
 
-				for i := 1; i <= 1000; i++ {
+				for i := 1; i <= 500; i++ {
 					person := db.Person{
 						ID:          uint(i),
 						Uuid:        fmt.Sprintf("uuid-%d", i),
@@ -530,7 +530,7 @@ func TestGetWantedsHeader(t *testing.T) {
 					assert.NoError(t, err)
 				}
 
-				for i := 1; i <= 500; i++ {
+				for i := 1; i <= 250; i++ {
 					bounty := db.Bounty{
 						Title:   fmt.Sprintf("Test Bounty %d", i),
 						OwnerID: fmt.Sprintf("test-pub-key-%d", i),
@@ -541,6 +541,10 @@ func TestGetWantedsHeader(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			validate: func(t *testing.T, response []byte) {
+
+				expectedDeveloperCount := db.TestDB.CountDevelopers()
+				expectedBountiesCount := db.TestDB.CountBounties()
+
 				var result struct {
 					DeveloperCount int64               `json:"developer_count"`
 					BountiesCount  uint64              `json:"bounties_count"`
@@ -548,8 +552,8 @@ func TestGetWantedsHeader(t *testing.T) {
 				}
 				err := json.Unmarshal(response, &result)
 				assert.NoError(t, err)
-				assert.Equal(t, int64(1000), result.DeveloperCount)
-				assert.Equal(t, uint64(500), result.BountiesCount)
+				assert.Equal(t, expectedDeveloperCount, result.DeveloperCount)
+				assert.Equal(t, expectedBountiesCount, result.BountiesCount)
 				assert.NotNil(t, result.People)
 				assert.Equal(t, 3, len(*result.People))
 			},

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -12271,3 +12271,440 @@ func (_c *Database_GetLatestTicketByGroup_Call) RunAndReturn(run func(uuid.UUID)
 	_c.Call.Return(run)
 	return _c
 }
+
+func (_m *Database) CreateNotification(n *db.Notification) error {
+	ret := _m.Called(n)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateNotification")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*db.Notification) error); ok {
+		r0 = rf(n)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+type Database_CreateNotification_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) CreateNotification(n interface{}) *Database_CreateNotification_Call {
+	return &Database_CreateNotification_Call{Call: _e.mock.On("CreateNotification", n)}
+}
+
+func (_c *Database_CreateNotification_Call) Run(run func(n *db.Notification)) *Database_CreateNotification_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*db.Notification))
+	})
+	return _c
+}
+
+func (_c *Database_CreateNotification_Call) Return(_a0 error) *Database_CreateNotification_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Database_CreateNotification_Call) RunAndReturn(run func(*db.Notification) error) *Database_CreateNotification_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_m *Database) GetNotification(_a0 string) (*db.Notification, error) {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNotification")
+	}
+
+	var r0 *db.Notification
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*db.Notification, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(string) *db.Notification); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*db.Notification)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetNotification_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) GetNotification(_a0 interface{}) *Database_GetNotification_Call {
+	return &Database_GetNotification_Call{Call: _e.mock.On("GetNotification", _a0)}
+}
+
+func (_c *Database_GetNotification_Call) Run(run func(_a0 string)) *Database_GetNotification_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_GetNotification_Call) Return(_a0 *db.Notification, _a1 error) *Database_GetNotification_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetNotification_Call) RunAndReturn(run func(string) (*db.Notification, error)) *Database_GetNotification_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_m *Database) UpdateNotification(_a0 string, updates map[string]interface{}) error {
+	ret := _m.Called(_a0, updates)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateNotification")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, map[string]interface{}) error); ok {
+		r0 = rf(_a0, updates)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+type Database_UpdateNotification_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) UpdateNotification(_a0 interface{}, updates interface{}) *Database_UpdateNotification_Call {
+	return &Database_UpdateNotification_Call{Call: _e.mock.On("UpdateNotification", _a0, updates)}
+}
+
+func (_c *Database_UpdateNotification_Call) Run(run func(_a0 string, updates map[string]interface{})) *Database_UpdateNotification_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(map[string]interface{}))
+	})
+	return _c
+}
+
+func (_c *Database_UpdateNotification_Call) Return(_a0 error) *Database_UpdateNotification_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Database_UpdateNotification_Call) RunAndReturn(run func(string, map[string]interface{}) error) *Database_UpdateNotification_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_m *Database) DeleteNotification(_a0 string) error {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteNotification")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+type Database_DeleteNotification_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) DeleteNotification(_a0 interface{}) *Database_DeleteNotification_Call {
+	return &Database_DeleteNotification_Call{Call: _e.mock.On("DeleteNotification", _a0)}
+}
+
+func (_c *Database_DeleteNotification_Call) Run(run func(_a0 string)) *Database_DeleteNotification_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_DeleteNotification_Call) Return(_a0 error) *Database_DeleteNotification_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Database_DeleteNotification_Call) RunAndReturn(run func(string) error) *Database_DeleteNotification_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_m *Database) GetPendingNotifications() ([]db.Notification, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPendingNotifications")
+	}
+
+	var r0 []db.Notification
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]db.Notification, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []db.Notification); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.Notification)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetPendingNotifications_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) GetPendingNotifications() *Database_GetPendingNotifications_Call {
+	return &Database_GetPendingNotifications_Call{Call: _e.mock.On("GetPendingNotifications")}
+}
+
+func (_c *Database_GetPendingNotifications_Call) Run(run func()) *Database_GetPendingNotifications_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Database_GetPendingNotifications_Call) Return(_a0 []db.Notification, _a1 error) *Database_GetPendingNotifications_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetPendingNotifications_Call) RunAndReturn(run func() ([]db.Notification, error)) *Database_GetPendingNotifications_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_m *Database) GetFailedNotifications(maxRetries int) ([]db.Notification, error) {
+	ret := _m.Called(maxRetries)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFailedNotifications")
+	}
+
+	var r0 []db.Notification
+	var r1 error
+	if rf, ok := ret.Get(0).(func(int) ([]db.Notification, error)); ok {
+		return rf(maxRetries)
+	}
+	if rf, ok := ret.Get(0).(func(int) []db.Notification); ok {
+		r0 = rf(maxRetries)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.Notification)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(maxRetries)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetFailedNotifications_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) GetFailedNotifications(maxRetries interface{}) *Database_GetFailedNotifications_Call {
+	return &Database_GetFailedNotifications_Call{Call: _e.mock.On("GetFailedNotifications", maxRetries)}
+}
+
+func (_c *Database_GetFailedNotifications_Call) Run(run func(maxRetries int)) *Database_GetFailedNotifications_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int))
+	})
+	return _c
+}
+
+func (_c *Database_GetFailedNotifications_Call) Return(_a0 []db.Notification, _a1 error) *Database_GetFailedNotifications_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetFailedNotifications_Call) RunAndReturn(run func(int) ([]db.Notification, error)) *Database_GetFailedNotifications_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_m *Database) GetNotificationsByPubKey(pubKey string, limit int, offset int) ([]db.Notification, error) {
+	ret := _m.Called(pubKey, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNotificationsByPubKey")
+	}
+
+	var r0 []db.Notification
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, int, int) ([]db.Notification, error)); ok {
+		return rf(pubKey, limit, offset)
+	}
+	if rf, ok := ret.Get(0).(func(string, int, int) []db.Notification); ok {
+		r0 = rf(pubKey, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.Notification)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, int, int) error); ok {
+		r1 = rf(pubKey, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetNotificationsByPubKey_Call struct {
+	*mock.Call
+}
+
+
+func (_e *Database_Expecter) GetNotificationsByPubKey(pubKey interface{}, limit interface{}, offset interface{}) *Database_GetNotificationsByPubKey_Call {
+	return &Database_GetNotificationsByPubKey_Call{Call: _e.mock.On("GetNotificationsByPubKey", pubKey, limit, offset)}
+}
+
+func (_c *Database_GetNotificationsByPubKey_Call) Run(run func(pubKey string, limit int, offset int)) *Database_GetNotificationsByPubKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(int), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *Database_GetNotificationsByPubKey_Call) Return(_a0 []db.Notification, _a1 error) *Database_GetNotificationsByPubKey_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetNotificationsByPubKey_Call) RunAndReturn(run func(string, int, int) ([]db.Notification, error)) *Database_GetNotificationsByPubKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_m *Database) IncrementRetryCount(_a0 string) error {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IncrementRetryCount")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+type Database_IncrementRetryCount_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) IncrementRetryCount(_a0 interface{}) *Database_IncrementRetryCount_Call {
+	return &Database_IncrementRetryCount_Call{Call: _e.mock.On("IncrementRetryCount", _a0)}
+}
+
+func (_c *Database_IncrementRetryCount_Call) Run(run func(_a0 string)) *Database_IncrementRetryCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_IncrementRetryCount_Call) Return(_a0 error) *Database_IncrementRetryCount_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Database_IncrementRetryCount_Call) RunAndReturn(run func(string) error) *Database_IncrementRetryCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+func (_m *Database) GetNotificationCount(pubKey string) (int64, error) {
+	ret := _m.Called(pubKey)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNotificationCount")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (int64, error)); ok {
+		return rf(pubKey)
+	}
+	if rf, ok := ret.Get(0).(func(string) int64); ok {
+		r0 = rf(pubKey)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(pubKey)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetNotificationCount_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) GetNotificationCount(pubKey interface{}) *Database_GetNotificationCount_Call {
+	return &Database_GetNotificationCount_Call{Call: _e.mock.On("GetNotificationCount", pubKey)}
+}
+
+func (_c *Database_GetNotificationCount_Call) Run(run func(pubKey string)) *Database_GetNotificationCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_GetNotificationCount_Call) Return(_a0 int64, _a1 error) *Database_GetNotificationCount_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetNotificationCount_Call) RunAndReturn(run func(string) (int64, error)) *Database_GetNotificationCount_Call {
+	_c.Call.Return(run)
+	return _c
+}


### PR DESCRIPTION
### Describe the Changes:
- Implements database layer for managing notification records with CRUD operations, status tracking, and retry mechanism

Daily Bounty: https://community.sphinx.chat/bounty/3349

## Issue ticket number and link:
- **Bounty Number:** [ 3349 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3349](url) ]

### Evidence:

`Postgres DB`

![image](https://github.com/user-attachments/assets/c5804a16-bdda-4011-bb33-0afcf41c1b1d)

1- `CreateNotification`

![image](https://github.com/user-attachments/assets/8daad417-f146-4567-865a-8f9663886177)

2- `GetNotification`

![image](https://github.com/user-attachments/assets/afff2c83-a4b4-4f06-b1a0-5e699156819a)

3- `UpdateNotification`

![image](https://github.com/user-attachments/assets/18bc8c46-51e9-472a-818e-381210866e28)

4- `DeleteNotification`

![image](https://github.com/user-attachments/assets/1f31a702-5fcc-4bac-b6af-81c04334d36e)

5- `GetPendingNotifications`

![image](https://github.com/user-attachments/assets/06cf53e0-fd4c-4616-9894-775957bdd7eb)

6- `GetFailedNotifications`

![image](https://github.com/user-attachments/assets/2e7d8a2b-f644-4963-8ea9-be091db21e3f)

7- `GetNotificationsByPubKey`

![image](https://github.com/user-attachments/assets/5b834fb4-2260-4f2c-b7cc-770df4547a3d)

8- `IncrementRetryCount`

![image](https://github.com/user-attachments/assets/d19a41ea-59a5-4ce1-92c3-5f17aa21b5e4)

9- `GetNotificationCount`

![image](https://github.com/user-attachments/assets/da6a7305-d019-40e4-bf6d-1dd3f1a874a0)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR