### PR TITLE
posthog: added current_url so it easier to know which endpoint is being hit for the compressed hex

### DIFF
--- a/routes/index.go
+++ b/routes/index.go
@@ -274,6 +274,7 @@ func internalServerErrorHandler(next http.Handler) http.Handler {
 						"$session_id":     session_id,
 						"$event_type":     "backend_api_call",
 						"$elements_chain": hexCompressed,
+						"$current_url": r.URL.Path,
 					},
 				})
 			}


### PR DESCRIPTION
In this change I am passing the route that is being logged in the posthog request