### PR TITLE
Fix: Ensure Bounties and Tickets Cards Only Show Selected Workspace

### DIFF
--- a/db/interface.go
+++ b/db/interface.go
@@ -248,7 +248,7 @@ type Database interface {
 	GetEndpointByPath(path string) (Endpoint, error)
 	GetAllEndpoints() ([]Endpoint, error)
 	GetLatestTicketByGroup(ticketGroup uuid.UUID) (Tickets, error)
-	GetAllTicketGroups() ([]uuid.UUID, error)
+	GetAllTicketGroups(workspaceUuid string) ([]uuid.UUID, error)
 	GetFeaturedBountyById(id string) (FeaturedBounty, error)
 	GetAllFeaturedBounties() ([]FeaturedBounty, error)
 	CreateFeaturedBounty(bounty FeaturedBounty) error

--- a/db/tickets.go
+++ b/db/tickets.go
@@ -251,11 +251,12 @@ func (db database) GetLatestTicketByGroup(ticketGroup uuid.UUID) (Tickets, error
 	return ticket, nil
 }
 
-func (db database) GetAllTicketGroups() ([]uuid.UUID, error) {
+func (db database) GetAllTicketGroups(workspaceUuid string) ([]uuid.UUID, error) {
 	var groups []uuid.UUID
 	result := db.db.Model(&Tickets{}).
-		Select("DISTINCT ticket_group").
-		Where("ticket_group IS NOT NULL").
+		Joins("JOIN workspace_features ON tickets.feature_uuid = workspace_features.uuid").
+		Where("workspace_features.workspace_uuid = ? AND tickets.ticket_group IS NOT NULL", workspaceUuid).
+		Select("DISTINCT tickets.ticket_group").
 		Find(&groups)
 
 	if result.Error != nil {

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -1574,7 +1574,7 @@ func (h *bountyHandler) GetBountyCards(w http.ResponseWriter, r *http.Request) {
 func (h *bountyHandler) GenerateTicketCardResponse(workspaceUuid string) ([]db.BountyCard, error) {
 	var ticketCards []db.BountyCard
 
-	ticketGroups, err := h.db.GetAllTicketGroups()
+	ticketGroups, err := h.db.GetAllTicketGroups(workspaceUuid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ticket groups: %w", err)
 	}
@@ -1587,6 +1587,10 @@ func (h *bountyHandler) GenerateTicketCardResponse(workspaceUuid string) ([]db.B
 		}
 
 		feature := h.db.GetFeatureByUuid(ticket.FeatureUUID)
+		if feature.WorkspaceUuid != workspaceUuid {
+			continue
+		}
+
 		phase, _ := h.db.GetFeaturePhaseByUuid(ticket.FeatureUUID, ticket.PhaseUUID)
 		workspace := h.db.GetWorkspaceByUuid(feature.WorkspaceUuid)
 		bountyID := uint(ticket.UUID.ID())

--- a/handlers/bounty_test.go
+++ b/handlers/bounty_test.go
@@ -4167,7 +4167,7 @@ func TestWorkspaceIsolation(t *testing.T) {
 		assert.Empty(t, response, "Response should be empty for workspace with only features")
 	})
 
-	t.Run("should verify ticket lastest versions in workspace 1", func(t *testing.T) {
+	t.Run("should verify the ticket lastest versions in workspace 1", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(bHandler.GetBountyCards)
 

--- a/handlers/bounty_test.go
+++ b/handlers/bounty_test.go
@@ -3941,3 +3941,298 @@ func TestBountyTiming(t *testing.T) {
 		})
 	})
 }
+
+func TestWorkspaceIsolation(t *testing.T) {
+	teardownSuite := SetupSuite(t)
+	defer teardownSuite(t)
+
+	mockHttpClient := mocks.NewHttpClient(t)
+	bHandler := NewBountyHandler(mockHttpClient, db.TestDB)
+
+	db.CleanTestData()
+
+	// Create Workspace 1 and its components
+	workspace1 := db.Workspace{
+		ID:          1,
+		Uuid:        "test-workspace-1",
+		Name:        "Test Workspace 1",
+		Description: "Test Workspace 1 Description",
+		OwnerPubKey: "test-owner-1",
+	}
+	db.TestDB.CreateOrEditWorkspace(workspace1)
+
+	feature1 := db.WorkspaceFeatures{
+		Uuid:          "feature-1-uuid",
+		Name:          "Feature One",
+		WorkspaceUuid: workspace1.Uuid,
+	}
+	db.TestDB.CreateOrEditFeature(feature1)
+
+	phase1 := db.FeaturePhase{
+		Uuid:        "phase-1-uuid",
+		Name:        "Feature One Phase",
+		FeatureUuid: feature1.Uuid,
+	}
+	db.TestDB.CreateOrEditFeaturePhase(phase1)
+
+	// Create Workspace 2 and its components
+	workspace2 := db.Workspace{
+		ID:          2,
+		Uuid:        "test-workspace-2",
+		Name:        "Test Workspace 2",
+		Description: "Test Workspace 2 Description",
+		OwnerPubKey: "test-owner-2",
+	}
+	db.TestDB.CreateOrEditWorkspace(workspace2)
+
+	feature2 := db.WorkspaceFeatures{
+		Uuid:          "feature-2-uuid",
+		Name:          "Feature Two",
+		WorkspaceUuid: workspace2.Uuid,
+	}
+	db.TestDB.CreateOrEditFeature(feature2)
+
+	phase2 := db.FeaturePhase{
+		Uuid:        "phase-2-uuid",
+		Name:        "Feature Two Phase",
+		FeatureUuid: feature2.Uuid,
+	}
+	db.TestDB.CreateOrEditFeaturePhase(phase2)
+
+	// Create tickets for Workspace 1
+	ticket1Group := uuid.New()
+	ticket1 := db.Tickets{
+		UUID:        uuid.New(),
+		TicketGroup: &ticket1Group,
+		Name:        "Ticket 1",
+		FeatureUUID: feature1.Uuid,
+		PhaseUUID:   phase1.Uuid,
+		Status:      db.DraftTicket,
+	}
+	db.TestDB.CreateOrEditTicket(&ticket1)
+
+	ticket2 := db.Tickets{
+		UUID:        uuid.New(),
+		TicketGroup: &ticket1Group,
+		Name:        "Ticket 2",
+		FeatureUUID: feature1.Uuid,
+		PhaseUUID:   phase1.Uuid,
+		Status:      db.DraftTicket,
+		Version:     2,
+	}
+	db.TestDB.CreateOrEditTicket(&ticket2)
+
+	// Create tickets for Workspace 2
+	ticket3Group := uuid.New()
+	ticket3 := db.Tickets{
+		UUID:        uuid.New(),
+		TicketGroup: &ticket3Group,
+		Name:        "Phase 2 Ticket 1",
+		FeatureUUID: feature2.Uuid,
+		PhaseUUID:   phase2.Uuid,
+		Status:      db.DraftTicket,
+	}
+	db.TestDB.CreateOrEditTicket(&ticket3)
+
+	ticket4 := db.Tickets{
+		UUID:        uuid.New(),
+		TicketGroup: &ticket3Group,
+		Name:        "Phase 2 Ticket 2",
+		FeatureUUID: feature2.Uuid,
+		PhaseUUID:   phase2.Uuid,
+		Status:      db.DraftTicket,
+	}
+	db.TestDB.CreateOrEditTicket(&ticket4)
+
+	t.Run("should only return workspace 1 tickets", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetBountyCards)
+
+		req, err := http.NewRequest(http.MethodGet, "/gobounties/bounty-cards?workspace_uuid="+workspace1.Uuid, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		var response []db.BountyCard
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Should only contain tickets from workspace 1
+		for _, card := range response {
+			if card.TicketUUID != nil {
+				assert.Equal(t, workspace1.Uuid, card.Features.WorkspaceUuid)
+				assert.Contains(t, []string{"Ticket 1", "Ticket 2"}, card.Title)
+				assert.NotContains(t, []string{"Phase 2 Ticket 1", "Phase 2 Ticket 2"}, card.Title)
+			}
+		}
+	})
+
+	t.Run("should only return workspace 2 tickets", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetBountyCards)
+
+		req, err := http.NewRequest(http.MethodGet, "/gobounties/bounty-cards?workspace_uuid="+workspace2.Uuid, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		var response []db.BountyCard
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Should only contain tickets from workspace 2
+		for _, card := range response {
+			if card.TicketUUID != nil {
+				assert.Equal(t, workspace2.Uuid, card.Features.WorkspaceUuid)
+				assert.Contains(t, []string{"Phase 2 Ticket 1", "Phase 2 Ticket 2"}, card.Title)
+				assert.NotContains(t, []string{"Ticket 1", "Ticket 2"}, card.Title)
+			}
+		}
+	})
+
+	t.Run("should handle non-existent workspace", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetBountyCards)
+
+		req, err := http.NewRequest(http.MethodGet, "/gobounties/bounty-cards?workspace_uuid=non-existent", nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		var response []db.BountyCard
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Empty(t, response, "Response should be empty for non-existent workspace")
+	})
+
+	t.Run("should handle workspace with no tickets", func(t *testing.T) {
+
+		emptyWorkspace := db.Workspace{
+			ID:          3,
+			Uuid:        "empty-workspace",
+			Name:        "Empty Workspace",
+			Description: "Workspace with no tickets",
+			OwnerPubKey: "test-owner-3",
+		}
+		db.TestDB.CreateOrEditWorkspace(emptyWorkspace)
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetBountyCards)
+
+		req, err := http.NewRequest(http.MethodGet, "/gobounties/bounty-cards?workspace_uuid="+emptyWorkspace.Uuid, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		var response []db.BountyCard
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Empty(t, response, "Response should be empty for workspace with no tickets")
+	})
+
+	t.Run("should handle workspace with only features but no tickets", func(t *testing.T) {
+
+		featureOnlyWorkspace := db.Workspace{
+			ID:          4,
+			Uuid:        "feature-only-workspace",
+			Name:        "Feature Only Workspace",
+			Description: "Workspace with features but no tickets",
+			OwnerPubKey: "test-owner-4",
+		}
+		db.TestDB.CreateOrEditWorkspace(featureOnlyWorkspace)
+
+		featureOnly := db.WorkspaceFeatures{
+			Uuid:          "feature-only-uuid",
+			Name:          "Feature Without Tickets",
+			WorkspaceUuid: featureOnlyWorkspace.Uuid,
+		}
+		db.TestDB.CreateOrEditFeature(featureOnly)
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetBountyCards)
+
+		req, err := http.NewRequest(http.MethodGet, "/gobounties/bounty-cards?workspace_uuid="+featureOnlyWorkspace.Uuid, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		var response []db.BountyCard
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Empty(t, response, "Response should be empty for workspace with only features")
+	})
+
+	t.Run("should verify ticket lastest versions in workspace 1", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetBountyCards)
+
+		req, err := http.NewRequest(http.MethodGet, "/gobounties/bounty-cards?workspace_uuid="+workspace1.Uuid, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		var response []db.BountyCard
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		var foundVersion2 bool
+		for _, card := range response {
+			if card.Title == "Ticket 2" {
+				foundVersion2 = true
+				break
+			}
+		}
+		assert.True(t, foundVersion2, "Should find ticket with version 2")
+	})
+
+	t.Run("should verify feature and phase relationships", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetBountyCards)
+
+		req, err := http.NewRequest(http.MethodGet, "/gobounties/bounty-cards?workspace_uuid="+workspace1.Uuid, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		var response []db.BountyCard
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		for _, card := range response {
+			if card.TicketUUID != nil {
+
+				assert.Equal(t, feature1.Uuid, card.Features.Uuid, "Feature UUID should match")
+				assert.Equal(t, feature1.Name, card.Features.Name, "Feature name should match")
+
+				assert.Equal(t, phase1.Uuid, card.Phase.Uuid, "Phase UUID should match")
+				assert.Equal(t, phase1.Name, card.Phase.Name, "Phase name should match")
+				assert.Equal(t, phase1.FeatureUuid, card.Phase.FeatureUuid, "Phase's feature UUID should match")
+			}
+		}
+	})
+
+	t.Run("should verify ticket status is draft", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetBountyCards)
+
+		req, err := http.NewRequest(http.MethodGet, "/gobounties/bounty-cards?workspace_uuid="+workspace1.Uuid, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		var response []db.BountyCard
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		for _, card := range response {
+			if card.TicketUUID != nil {
+				assert.Equal(t, db.StatusDraft, card.Status, "Ticket status should be draft")
+			}
+		}
+	})
+}

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -3294,9 +3294,9 @@ func (_c *Database_GetAllFeaturedBounties_Call) RunAndReturn(run func() ([]db.Fe
 	return _c
 }
 
-// GetAllTicketGroups provides a mock function with no fields
-func (_m *Database) GetAllTicketGroups() ([]uuid.UUID, error) {
-	ret := _m.Called()
+// GetAllTicketGroups provides a mock function with given fields: workspaceUuid
+func (_m *Database) GetAllTicketGroups(workspaceUuid string) ([]uuid.UUID, error) {
+	ret := _m.Called(workspaceUuid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllTicketGroups")
@@ -3304,19 +3304,19 @@ func (_m *Database) GetAllTicketGroups() ([]uuid.UUID, error) {
 
 	var r0 []uuid.UUID
 	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]uuid.UUID, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(string) ([]uuid.UUID, error)); ok {
+		return rf(workspaceUuid)
 	}
-	if rf, ok := ret.Get(0).(func() []uuid.UUID); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) []uuid.UUID); ok {
+		r0 = rf(workspaceUuid)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]uuid.UUID)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(workspaceUuid)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -3330,13 +3330,14 @@ type Database_GetAllTicketGroups_Call struct {
 }
 
 // GetAllTicketGroups is a helper method to define mock.On call
-func (_e *Database_Expecter) GetAllTicketGroups() *Database_GetAllTicketGroups_Call {
-	return &Database_GetAllTicketGroups_Call{Call: _e.mock.On("GetAllTicketGroups")}
+//   - workspaceUuid string
+func (_e *Database_Expecter) GetAllTicketGroups(workspaceUuid interface{}) *Database_GetAllTicketGroups_Call {
+	return &Database_GetAllTicketGroups_Call{Call: _e.mock.On("GetAllTicketGroups", workspaceUuid)}
 }
 
-func (_c *Database_GetAllTicketGroups_Call) Run(run func()) *Database_GetAllTicketGroups_Call {
+func (_c *Database_GetAllTicketGroups_Call) Run(run func(workspaceUuid string)) *Database_GetAllTicketGroups_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -3346,7 +3347,7 @@ func (_c *Database_GetAllTicketGroups_Call) Return(_a0 []uuid.UUID, _a1 error) *
 	return _c
 }
 
-func (_c *Database_GetAllTicketGroups_Call) RunAndReturn(run func() ([]uuid.UUID, error)) *Database_GetAllTicketGroups_Call {
+func (_c *Database_GetAllTicketGroups_Call) RunAndReturn(run func(string) ([]uuid.UUID, error)) *Database_GetAllTicketGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Describe the Changes:
- Filters ticket groups by workspace UUID to ensure only tickets from the selected workspace are displayed in the bounty cards view

Daily Bounty: https://community.sphinx.chat/bounty/3398

## Issue ticket number and link:
- **Bounty Number:** [ 3398 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3398](url) ]

### Evidence:

#### `Loom:`

https://www.loom.com/share/5282bae7ebf147fd984484fbd36090d9

https://www.loom.com/share/997feada2d8c4093905ecff01aa988da

#### `Unit Test:`

![image](https://github.com/user-attachments/assets/4d8108b5-dad1-4a7e-88b0-db7076d2154f)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR