### PR TITLE
Update `Stakwork` Send Calls to include User Alias

### DIFF
--- a/db/tickets_test.go
+++ b/db/tickets_test.go
@@ -121,7 +121,7 @@ func TestCreateOrEditTicket(t *testing.T) {
 	})
 
 	// shpuld create a ticket if all fields are provided
-	t.Run("should create a ticket if the all fields are provided", func(t *testing.T) {
+	t.Run("should create a ticket if all fields are provided", func(t *testing.T) {
 
 		_, err := TestDB.CreateOrEditTicket(&ticket)
 		if err != nil {

--- a/db/tickets_test.go
+++ b/db/tickets_test.go
@@ -121,7 +121,7 @@ func TestCreateOrEditTicket(t *testing.T) {
 	})
 
 	// shpuld create a ticket if all fields are provided
-	t.Run("should create a ticket if all fields are provided", func(t *testing.T) {
+	t.Run("should create a ticket if the all fields are provided", func(t *testing.T) {
 
 		_, err := TestDB.CreateOrEditTicket(&ticket)
 		if err != nil {

--- a/handlers/chat.go
+++ b/handlers/chat.go
@@ -17,6 +17,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stakwork/sphinx-tribes/auth"
+	"github.com/stakwork/sphinx-tribes/logger"
+
 	"github.com/google/uuid"
 	"github.com/rs/xid"
 	"github.com/stakwork/sphinx-tribes/websocket"
@@ -222,6 +225,22 @@ func (ch *ChatHandler) ArchiveChat(w http.ResponseWriter, r *http.Request) {
 
 func (ch *ChatHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 
+	ctx := r.Context()
+	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
+	if pubKeyFromAuth == "" {
+		logger.Log.Info("no pubkey from auth")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	user := ch.db.GetPersonByPubkey(pubKeyFromAuth)
+
+	if user.OwnerPubKey != pubKeyFromAuth {
+		logger.Log.Info("Person not exists")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	var request struct {
 		ChatID      string `json:"chat_id"`
 		Message     string `json:"message"`
@@ -319,6 +338,7 @@ func (ch *ChatHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 						"contextTags":       context,
 						"sourceWebsocketId": request.SourceWebsocketID,
 						"webhook_url":       fmt.Sprintf("%s/hivechat/response", os.Getenv("HOST")),
+						"alias":             user.OwnerAlias,
 					},
 				},
 			},

--- a/handlers/features.go
+++ b/handlers/features.go
@@ -27,6 +27,7 @@ type PostData struct {
 	Examples     []string `json:"examples"`
 	WebhookURL   string   `json:"webhook_url"`
 	FeatureUUID  string   `json:"featureUUID"`
+	Alias        string   `json:"alias"`
 }
 
 type FeatureBriefRequest struct {
@@ -585,6 +586,22 @@ func (oh *featureHandler) GetFeatureStories(w http.ResponseWriter, r *http.Reque
 
 func (oh *featureHandler) StoriesSend(w http.ResponseWriter, r *http.Request) {
 
+	ctx := r.Context()
+	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
+	if pubKeyFromAuth == "" {
+		logger.Log.Info("no pubkey from auth")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	user := oh.db.GetPersonByPubkey(pubKeyFromAuth)
+
+	if user.OwnerPubKey != pubKeyFromAuth {
+		logger.Log.Info("Person not exists")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
@@ -605,6 +622,8 @@ func (oh *featureHandler) StoriesSend(w http.ResponseWriter, r *http.Request) {
 		panic("API key not set in environment")
 		return
 	}
+
+	postData.Alias = user.OwnerAlias
 
 	stakworkPayload := map[string]interface{}{
 		"name":        "string",
@@ -659,6 +678,14 @@ func (oh *featureHandler) BriefSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	user := oh.db.GetPersonByPubkey(pubKeyFromAuth)
+
+	if user.OwnerPubKey != pubKeyFromAuth {
+		logger.Log.Info("Person not exists")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
@@ -684,9 +711,11 @@ func (oh *featureHandler) BriefSend(w http.ResponseWriter, r *http.Request) {
 	completePostData := struct {
 		AudioBriefPostData
 		WebhookURL string `json:"webhook_url"`
+		Alias      string `json:"alias"`
 	}{
 		AudioBriefPostData: postData,
 		WebhookURL:         fmt.Sprintf("%s/feature/brief", host),
+		Alias:              user.OwnerAlias,
 	}
 
 	apiKey := os.Getenv("SWWFKEY")

--- a/handlers/features_test.go
+++ b/handlers/features_test.go
@@ -4691,6 +4691,16 @@ func TestBriefSend(t *testing.T) {
 
 	db.CleanTestData()
 
+	person := db.Person{
+		Uuid:        uuid.New().String(),
+		OwnerAlias:  "test-alias",
+		UniqueName:  "test-unique-name",
+		OwnerPubKey: "test-pubkey",
+		PriceToMeet: 0,
+		Description: "test-description",
+	}
+	db.TestDB.CreateOrEditPerson(person)
+
 	fHandler := NewFeatureHandler(db.TestDB)
 
 	tests := []struct {
@@ -4708,7 +4718,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Valid Request with All Required Fields",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           `{"audioLink":"link","featureUUID":"uuid","source":"source","examples":["example1"]}`,
 			envHost:        "http://localhost",
 			envSWWFKEY:     "validKey",
@@ -4718,7 +4728,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Empty JSON Body",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           ``,
 			expectedStatus: http.StatusNotAcceptable,
 			expectedBody:   "Invalid JSON format\n",
@@ -4726,7 +4736,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Missing Required JSON Fields",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           `{"audioLink":"link"}`,
 			envHost:        "http://localhost",
 			envSWWFKEY:     "",
@@ -4743,7 +4753,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Invalid JSON Format",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           `{"audioLink":}`,
 			expectedStatus: http.StatusNotAcceptable,
 			expectedBody:   "Invalid JSON format\n",
@@ -4751,7 +4761,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Environment Variable HOST Not Set",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           `{"audioLink":"link","featureUUID":"uuid","source":"source","examples":["example1"]}`,
 			envHost:        "",
 			envSWWFKEY:     "validKey",
@@ -4760,7 +4770,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Environment Variable SWWFKEY Not Set",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           `{"audioLink":"link","featureUUID":"uuid","source":"source","examples":["example1"]}`,
 			envHost:        "",
 			envSWWFKEY:     "validKey",
@@ -4769,7 +4779,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Stakwork API Request Creation Failure",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           `{"audioLink":"link","featureUUID":"uuid","source":"source","examples":["example1"]}`,
 			envHost:        "http://localhost",
 			envSWWFKEY:     "validKey",
@@ -4779,7 +4789,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Stakwork API Request Sending Failure",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           `{"audioLink":"link","featureUUID":"uuid","source":"source","examples":["example1"]}`,
 			envHost:        "http://localhost",
 			envSWWFKEY:     "validKey",
@@ -4789,7 +4799,7 @@ func TestBriefSend(t *testing.T) {
 		{
 			name:           "Stakwork API Response Reading Failure",
 			contextKey:     auth.ContextKey,
-			contextValue:   "validPubKey",
+			contextValue:   "test-pubkey",
 			body:           `{"audioLink":"link","featureUUID":"uuid","source":"source","examples":["example1"]}`,
 			envHost:        "http://localhost",
 			envSWWFKEY:     "validKey",

--- a/handlers/features_test.go
+++ b/handlers/features_test.go
@@ -4777,7 +4777,7 @@ func TestBriefSend(t *testing.T) {
 			expectedStatus: http.StatusNotAcceptable,
 		},
 		{
-			name:           "Stakwork API Request Creation Failure",
+			name:           "Stakwork the API Request Creation Failure",
 			contextKey:     auth.ContextKey,
 			contextValue:   "test-pubkey",
 			body:           `{"audioLink":"link","featureUUID":"uuid","source":"source","examples":["example1"]}`,

--- a/handlers/ticket.go
+++ b/handlers/ticket.go
@@ -322,6 +322,14 @@ func (th *ticketHandler) PostTicketDataToStakwork(w http.ResponseWriter, r *http
 		return
 	}
 
+	user := th.db.GetPersonByPubkey(pubKeyFromAuth)
+
+	if user.OwnerPubKey != pubKeyFromAuth {
+		logger.Log.Info("Person not exists")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -479,6 +487,7 @@ func (th *ticketHandler) PostTicketDataToStakwork(w http.ResponseWriter, r *http
 						"webhook_url":       webhookURL,
 						"phaseSchematic":    schematicURL,
 						"codeGraph":         codeGraphURL,
+						"alias":             user.OwnerAlias,
 					},
 				},
 			},


### PR DESCRIPTION
### Describe the Changes:
- Adds user alias to Stakwork payloads in BriefSend, StoriesSend, SendMessage and PostTicketDataToStakwork handlers for improved personalization in Hive Chain of Thought reasoning

Daily Bounty: https://community.sphinx.chat/bounty/3441

## Issue ticket number and link:
- **Bounty Number:** [ 3441 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3441](url) ]


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR