### PR TITLE
Feature: Add Endpoint to Delete Bounty Timing Records

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -2086,3 +2086,16 @@ func (db database) UpdateFeaturedBounty(bountyID string, bounty FeaturedBounty) 
 func (db database) DeleteFeaturedBounty(bountyID string) error {
 	return db.db.Where("bounty_id = ?", bountyID).Delete(&FeaturedBounty{}).Error
 }
+
+func (db database) DeleteBountyTiming(bountyID uint) error {
+	result := db.db.Where("bounty_id = ?", bountyID).Delete(&BountyTiming{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete bounty timing: %w", result.Error)
+	}
+
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("no timing record found for bounty %d", bountyID)
+	}
+
+	return nil
+}

--- a/db/interface.go
+++ b/db/interface.go
@@ -279,4 +279,5 @@ type Database interface {
 	ListFileAssets(params ListFileAssetsParams) ([]FileAsset, int64, error)
 	UpdateFileAsset(asset *FileAsset) error
 	DeleteFileAsset(id uint) error
+	DeleteBountyTiming(bountyID uint) error
 }

--- a/db/test_config.go
+++ b/db/test_config.go
@@ -102,6 +102,8 @@ func CleanTestData() {
 
 	TestDB.DeleteAllBounties()
 
+	TestDB.db.Exec("DELETE FROM bounty_timings")
+
 	TestDB.db.Exec("DELETE FROM workspaces")
 
 	TestDB.db.Exec("DELETE FROM workspace_features")

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -2097,6 +2097,15 @@ func (h *bountyHandler) DeleteFeaturedBounty(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *bountyHandler) DeleteBountyTiming(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
+	if pubKeyFromAuth == "" {
+		logger.Log.Info("no pubkey from auth")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
 	bountyID := chi.URLParam(r, "id")
 	id, err := utils.ConvertStringToUint(bountyID)
 	if err != nil {

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -2095,3 +2095,29 @@ func (h *bountyHandler) DeleteFeaturedBounty(w http.ResponseWriter, r *http.Requ
 
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func (h *bountyHandler) DeleteBountyTiming(w http.ResponseWriter, r *http.Request) {
+	bountyID := chi.URLParam(r, "id")
+	id, err := utils.ConvertStringToUint(bountyID)
+	if err != nil {
+		http.Error(w, "Invalid bounty ID", http.StatusBadRequest)
+		return
+	}
+
+	_, err = h.db.GetBountyTiming(id)
+	if err != nil {
+		logger.Log.Error(fmt.Sprintf("No bounty timing found for bounty ID %d: %v", id, err))
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "No timing record found"})
+		return
+	}
+
+	if err := h.db.DeleteBountyTiming(id); err != nil {
+		logger.Log.Error(fmt.Sprintf("Failed to delete bounty timing for bounty ID %d: %v", id, err))
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to delete bounty timing"})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -13585,3 +13585,45 @@ func (_c *Database_DeleteFileAsset_Call) RunAndReturn(run func(uint) error) *Dat
 	return _c
 }
 
+// DeleteBountyTiming provides a mock function with given fields: bountyID
+func (_m *Database) DeleteBountyTiming(bountyID uint) error {
+	ret := _m.Called(bountyID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteBountyTiming")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(uint) error); ok {
+		r0 = rf(bountyID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+type Database_DeleteBountyTiming_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) DeleteBountyTiming(bountyID interface{}) *Database_DeleteBountyTiming_Call {
+	return &Database_DeleteBountyTiming_Call{Call: _e.mock.On("DeleteBountyTiming", bountyID)}
+}
+
+func (_c *Database_DeleteBountyTiming_Call) Run(run func(bountyID uint)) *Database_DeleteBountyTiming_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(uint))
+	})
+	return _c
+}
+
+func (_c *Database_DeleteBountyTiming_Call) Return(_a0 error) *Database_DeleteBountyTiming_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Database_DeleteBountyTiming_Call) RunAndReturn(run func(uint) error) *Database_DeleteBountyTiming_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/routes/bounty.go
+++ b/routes/bounty.go
@@ -1,8 +1,9 @@
 package routes
 
 import (
-	"github.com/stakwork/sphinx-tribes/auth"
 	"net/http"
+
+	"github.com/stakwork/sphinx-tribes/auth"
 
 	"github.com/go-chi/chi"
 	"github.com/stakwork/sphinx-tribes/db"
@@ -60,6 +61,7 @@ func BountyRoutes() chi.Router {
 		r.Get("/{id}/timing", bountyHandler.GetBountyTimingStats)
 		r.Put("/{id}/timing/start", bountyHandler.StartBountyTiming)
 		r.Put("/{id}/timing/close", bountyHandler.CloseBountyTiming)
+		r.Delete("/{id}/timing", bountyHandler.DeleteBountyTiming)
 	})
 	return r
 }


### PR DESCRIPTION
### Describe the Changes:
- Add an authenticated endpoint to delete bounty timing records for reassigning bounties

Daily Bounty: https://community.sphinx.chat/bounty/3470

## Issue ticket number and link:
- **Bounty Number:** [ 3470 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3470](url) ]

### Evidence:

#### `Loom:`

https://www.loom.com/share/674bb131b82f4434bdcd73d82fa04b7e

![image](https://github.com/user-attachments/assets/6ab96779-a0c0-4a88-aa25-d29421bfd784)

![image](https://github.com/user-attachments/assets/822bf9eb-5404-410f-a1ea-49df2128598d)

![image](https://github.com/user-attachments/assets/fa7fd741-4473-46cd-904f-ec0563ea9064)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR