### PR TITLE
Feature: Workspace Time-Range Bounty Endpoint with Knowledge Graph Structure

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -2168,3 +2168,23 @@ func (db database) DeleteBountyTiming(bountyID uint) error {
 
 	return nil
 }
+
+func (db database) GetBountiesByWorkspaceAndTimeRange(workspaceId string, startDate time.Time, endDate time.Time) ([]NewBounty, error) {
+    var bounties []NewBounty
+    
+    startTimestamp := startDate.Unix()
+    endTimestamp := endDate.Unix()
+    
+    query := db.db.
+        Where("workspace_uuid = ? AND created >= ? AND show = true", workspaceId, startTimestamp)
+
+    if endTimestamp < time.Now().Unix() {
+        query = query.Where("created <= ?", endTimestamp)
+    }
+    
+    err := query.
+        Order("created DESC").
+        Find(&bounties).Error
+        
+    return bounties, err
+}

--- a/db/interface.go
+++ b/db/interface.go
@@ -285,9 +285,10 @@ type Database interface {
 	PauseBountyTiming(bountyID uint) error
 	ResumeBountyTiming(bountyID uint) error
 	CreateOrEditTicketPlan(plan *TicketPlan) (*TicketPlan, error)
-    GetTicketPlan(uuid string) (*TicketPlan, error)
-    DeleteTicketPlan(uuid string) error
-    GetTicketPlansByFeature(featureUUID string) ([]TicketPlan, error)
-    GetTicketPlansByPhase(phaseUUID string) ([]TicketPlan, error)
-    GetTicketPlansByWorkspace(workspaceUUID string) ([]TicketPlan, error)
+	GetTicketPlan(uuid string) (*TicketPlan, error)
+	DeleteTicketPlan(uuid string) error
+	GetTicketPlansByFeature(featureUUID string) ([]TicketPlan, error)
+	GetTicketPlansByPhase(phaseUUID string) ([]TicketPlan, error)
+	GetTicketPlansByWorkspace(workspaceUUID string) ([]TicketPlan, error)
+	GetBountiesByWorkspaceAndTimeRange(workspaceId string, startDate time.Time, endDate time.Time) ([]NewBounty, error)
 }

--- a/db/structs.go
+++ b/db/structs.go
@@ -1289,6 +1289,17 @@ type TicketPlan struct {
     UpdatedAt     time.Time         `gorm:"type:timestamp;default:current_timestamp" json:"updated_at"`
 }
 
+type NodeData struct {
+    BountyID    uint   `json:"bounty_id"`
+    Title       string `json:"title"`
+    Description string `json:"description"`
+}
+
+type NodeResponse struct {
+    NodeType string     `json:"node_type"`
+    NodeData []NodeData `json:"node_data"`
+}
+
 func (Person) TableName() string {
 	return "people"
 }

--- a/db/structs.go
+++ b/db/structs.go
@@ -1295,9 +1295,13 @@ type NodeData struct {
     Description string `json:"description"`
 }
 
-type NodeResponse struct {
-    NodeType string     `json:"node_type"`
-    NodeData []NodeData `json:"node_data"`
+type Node struct {
+    NodeType string   `json:"node_type"`
+    NodeData NodeData `json:"node_data"`
+}
+
+type NodeListResponse struct {
+    NodeList []Node `json:"node_list"`
 }
 
 func (Person) TableName() string {

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -2135,3 +2135,62 @@ func (h *bountyHandler) DeleteBountyTiming(w http.ResponseWriter, r *http.Reques
 
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func (h *bountyHandler) GetBountiesByWorkspaceTime(w http.ResponseWriter, r *http.Request) {
+
+	workspaceId := chi.URLParam(r, "workspaceId")
+	daysStartStr := chi.URLParam(r, "daysStart")
+	daysEndStr := chi.URLParam(r, "daysEnd")
+
+	daysStart, err := strconv.Atoi(daysStartStr)
+	if err != nil {
+		http.Error(w, "Invalid daysStart parameter", http.StatusBadRequest)
+		return
+	}
+
+	daysEnd, err := strconv.Atoi(daysEndStr)
+	if err != nil {
+		http.Error(w, "Invalid daysEnd parameter", http.StatusBadRequest)
+		return
+	}
+
+	if workspaceId == "" {
+		http.Error(w, "Workspace ID is required", http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now()
+	var endDate time.Time
+	
+	if daysStart == 0 {
+		endDate = now.AddDate(0, 0, 1)
+	} else {
+		endDate = now.AddDate(0, 0, -daysStart)
+	}
+	
+	startDate := now.AddDate(0, 0, -daysEnd)
+
+	bounties, err := h.db.GetBountiesByWorkspaceAndTimeRange(workspaceId, startDate, endDate)
+	if err != nil {
+		logger.Log.Error("[bounty] Error retrieving bounties: %v", err)
+		http.Error(w, "Error retrieving bounties", http.StatusInternalServerError)
+		return
+	}
+
+	nodeData := make([]db.NodeData, len(bounties))
+	for i, bounty := range bounties {
+		nodeData[i] = db.NodeData{
+			BountyID:    bounty.ID,
+			Title:       bounty.Title,
+			Description: bounty.Description,
+		}
+	}
+
+	response := db.NodeResponse{
+		NodeType: "Bounty",
+		NodeData: nodeData,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -2177,18 +2177,20 @@ func (h *bountyHandler) GetBountiesByWorkspaceTime(w http.ResponseWriter, r *htt
 		return
 	}
 
-	nodeData := make([]db.NodeData, len(bounties))
+	nodes := make([]db.Node, len(bounties))
 	for i, bounty := range bounties {
-		nodeData[i] = db.NodeData{
-			BountyID:    bounty.ID,
-			Title:       bounty.Title,
-			Description: bounty.Description,
+		nodes[i] = db.Node{
+			NodeType: "Bounty",
+			NodeData: db.NodeData{
+				BountyID:    bounty.ID,
+				Title:       bounty.Title,
+				Description: bounty.Description,
+			},
 		}
 	}
 
-	response := db.NodeResponse{
-		NodeType: "Bounty",
-		NodeData: nodeData,
+	response := db.NodeListResponse{
+		NodeList: nodes,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/handlers/bounty_test.go
+++ b/handlers/bounty_test.go
@@ -4283,7 +4283,7 @@ func TestDeleteBountyTiming(t *testing.T) {
 	_, err = db.TestDB.CreateBountyTiming(createdBounty.ID)
 	assert.NoError(t, err)
 
-	t.Run("should return 401 if no pubkey in context", func(t *testing.T) {
+	t.Run("should return 401 if no - pubkey in context", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(bHandler.DeleteBountyTiming)
 

--- a/handlers/bounty_test.go
+++ b/handlers/bounty_test.go
@@ -4283,7 +4283,7 @@ func TestDeleteBountyTiming(t *testing.T) {
 	_, err = db.TestDB.CreateBountyTiming(createdBounty.ID)
 	assert.NoError(t, err)
 
-	t.Run("should return 401 if no - pubkey in context", func(t *testing.T) {
+	t.Run("should return 401 if no pubkey in context", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(bHandler.DeleteBountyTiming)
 

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -14126,3 +14126,58 @@ func (_c *Database_GetTicketPlansByWorkspace_Call) RunAndReturn(run func(string)
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetBountiesByWorkspaceAndTimeRange provides a mock function with given fields: workspaceId, startDate, endDate
+func (_m *Database) GetBountiesByWorkspaceAndTimeRange(workspaceId string, startDate time.Time, endDate time.Time) ([]db.NewBounty, error) {
+	ret := _m.Called(workspaceId, startDate, endDate)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBountiesByWorkspaceAndTimeRange")
+	}
+
+	var r0 []db.NewBounty
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, time.Time, time.Time) ([]db.NewBounty, error)); ok {
+		return rf(workspaceId, startDate, endDate)
+	}
+	if rf, ok := ret.Get(0).(func(string, time.Time, time.Time) []db.NewBounty); ok {
+		r0 = rf(workspaceId, startDate, endDate)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.NewBounty)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, time.Time, time.Time) error); ok {
+		r1 = rf(workspaceId, startDate, endDate)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetBountiesByWorkspaceAndTimeRange_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) GetBountiesByWorkspaceAndTimeRange(workspaceId interface{}, startDate interface{}, endDate interface{}) *Database_GetBountiesByWorkspaceAndTimeRange_Call {
+	return &Database_GetBountiesByWorkspaceAndTimeRange_Call{Call: _e.mock.On("GetBountiesByWorkspaceAndTimeRange", workspaceId, startDate, endDate)}
+}
+
+func (_c *Database_GetBountiesByWorkspaceAndTimeRange_Call) Run(run func(workspaceId string, startDate time.Time, endDate time.Time)) *Database_GetBountiesByWorkspaceAndTimeRange_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(time.Time), args[2].(time.Time))
+	})
+	return _c
+}
+
+func (_c *Database_GetBountiesByWorkspaceAndTimeRange_Call) Return(_a0 []db.NewBounty, _a1 error) *Database_GetBountiesByWorkspaceAndTimeRange_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetBountiesByWorkspaceAndTimeRange_Call) RunAndReturn(run func(string, time.Time, time.Time) ([]db.NewBounty, error)) *Database_GetBountiesByWorkspaceAndTimeRange_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/routes/bounty.go
+++ b/routes/bounty.go
@@ -31,7 +31,7 @@ func BountyRoutes() chi.Router {
 		r.Get("/count", handlers.GetBountyCount)
 		r.Get("/invoice/{paymentRequest}", bountyHandler.GetInvoiceData)
 		r.Get("/filter/count", bountyHandler.GetFilterCount)
-
+		r.Get("/workspace/timerange/{workspaceId}/{daysStart}/{daysEnd}", bountyHandler.GetBountiesByWorkspaceTime)
 	})
 	r.Group(func(r chi.Router) {
 		r.Use(auth.PubKeyContext)


### PR DESCRIPTION
### Describe the Changes:
- Adds endpoint to fetch workspace bounties within a specified time range, formatted as knowledge graph nodes

Daily Bounty: https://community.sphinx.chat/bounty/3623

## Issue ticket number and link:
- **Bounty Number:** [ 3623 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3623](url) ]


#### `Loom:`

https://www.loom.com/share/525cd028f3cd412b9d3bad96f3246ce7

![image](https://github.com/user-attachments/assets/5a737fdd-7f35-4e09-98b6-c7a18f4cfb9b)

![image](https://github.com/user-attachments/assets/e9114d63-54a5-4b1a-8822-8873999ed1bf)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR