### PR TITLE
Add `secret_alias` field to Code Graph Implementation And Unit Test

### DIFF
--- a/db/structs.go
+++ b/db/structs.go
@@ -593,6 +593,7 @@ type WorkspaceCodeGraph struct {
 	WorkspaceUuid string     `gorm:"not null" json:"workspace_uuid"`
 	Name          string     `gorm:"not null" json:"name"`
 	Url           string     `json:"url"`
+	SecretAlias   string     `json:"secret_alias"`
 	Created       *time.Time `json:"created"`
 	Updated       *time.Time `json:"updated"`
 	CreatedBy     string     `json:"created_by"`
@@ -1256,9 +1257,9 @@ type FileAsset struct {
 type ListFileAssetsParams struct {
 	Status             *FileStatus `form:"status"`
 	MimeType           *string     `form:"mimeType"`
-	BeforeDate         *time.Time  `form:"beforeDate"`
-	AfterDate          *time.Time  `form:"afterDate"`
-	LastAccessedBefore *time.Time  `form:"lastAccessedBefore"`
+	BeforeDate         *time.Time    `form:"beforeDate"`
+	AfterDate          *time.Time    `form:"afterDate"`
+	LastAccessedBefore *time.Time    `form:"lastAccessedBefore"`
 	WorkspaceID        *string     `form:"workspaceId"`
 	Page               int         `form:"page,default=1"`
 	PageSize           int         `form:"pageSize,default=50"`


### PR DESCRIPTION
### Describe the Changes:
- Add secret_alias field to Code Graph to enable Stakwork to use the correct secret when querying a code graph

Daily Bounty: https://community.sphinx.chat/bounty/3629

## Issue ticket number and link:
- **Bounty Number:** [ 3629 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3629](url) ]

### Evidence:

![Image](https://github.com/user-attachments/assets/8a074abe-8278-4714-8579-8fa07f7d34c5)

#### `Unit Test:`

![Image](https://github.com/user-attachments/assets/d84911ef-47b7-4079-9cf6-6aa040aca8db)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR