### PR TITLE
Add Webhook Endpoint for Activity Updates from Stakwork

### DIFF
--- a/handlers/activity_test.go
+++ b/handlers/activity_test.go
@@ -1,0 +1,191 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stakwork/sphinx-tribes/db"
+	"github.com/stretchr/testify/assert"
+)
+
+const validHumanAuthorRef = "02abc123456789abcdef0123456789abcdef0123"
+
+func TestReceiveActivity(t *testing.T) {
+	teardownSuite := SetupSuite(t)
+	defer teardownSuite(t)
+
+	ah := NewActivityHandler(&http.Client{}, db.TestDB)
+
+	tests := []struct {
+		name           string
+		payload        WebhookActivityRequest
+		expectedStatus int
+		expectedError  string
+		validateFunc   func(t *testing.T, resp WebhookResponse)
+	}{
+		{
+			name: "successful new activity creation",
+			payload: WebhookActivityRequest{
+				ContentType: "general_update",
+				Content:     "Test content",
+				Workspace:   "test-workspace",
+				Author:      db.HumansAuthor,
+				AuthorRef:   validHumanAuthorRef,
+			},
+			expectedStatus: http.StatusCreated,
+			validateFunc: func(t *testing.T, resp WebhookResponse) {
+				assert.True(t, resp.Success)
+				assert.NotEmpty(t, resp.ActivityID)
+
+				activity, err := db.TestDB.GetActivity(resp.ActivityID)
+				assert.NoError(t, err)
+				assert.Equal(t, "Test content", activity.Content)
+				assert.Equal(t, "test-workspace", activity.Workspace)
+			},
+		},
+		{
+			name: "successful thread activity creation",
+			payload: WebhookActivityRequest{
+				ContentType: "general_update",
+				Content:     "Thread reply",
+				Workspace:   "test-workspace",
+				ThreadID:    uuid.New().String(),
+				Author:      db.HumansAuthor,
+				AuthorRef:   validHumanAuthorRef,
+			},
+			expectedStatus: http.StatusCreated,
+			validateFunc: func(t *testing.T, resp WebhookResponse) {
+				assert.True(t, resp.Success)
+				assert.NotEmpty(t, resp.ActivityID)
+
+				activity, err := db.TestDB.GetActivity(resp.ActivityID)
+				assert.NoError(t, err)
+				assert.Equal(t, "Thread reply", activity.Content)
+				assert.Equal(t, "test-workspace", activity.Workspace)
+			},
+		},
+		{
+			name: "invalid content - empty",
+			payload: WebhookActivityRequest{
+				ContentType: "general_update",
+				Content:     "",
+				Workspace:   "test-workspace",
+				Author:      db.HumansAuthor,
+				AuthorRef:   validHumanAuthorRef,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "content must not be empty and must be less than 10000 characters",
+		},
+		{
+			name: "invalid author type",
+			payload: WebhookActivityRequest{
+				ContentType: "general_update",
+				Content:     "Test content",
+				Workspace:   "test-workspace",
+				Author:      "invalid",
+				AuthorRef:   validHumanAuthorRef,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid author type",
+		},
+		{
+			name: "invalid human author ref",
+			payload: WebhookActivityRequest{
+				ContentType: "general_update",
+				Content:     "Test content",
+				Workspace:   "test-workspace",
+				Author:      db.HumansAuthor,
+				AuthorRef:   "short",
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid public key format for human author",
+		},
+		{
+			name: "invalid hive author ref",
+			payload: WebhookActivityRequest{
+				ContentType: "general_update",
+				Content:     "Test content",
+				Workspace:   "test-workspace",
+				Author:      db.HiveAuthor,
+				AuthorRef:   "not-a-uuid",
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid UUID format for hive author",
+		},
+		{
+			name: "invalid thread ID format",
+			payload: WebhookActivityRequest{
+				ContentType: "general_update",
+				Content:     "Test content",
+				Workspace:   "test-workspace",
+				ThreadID:    "not-a-uuid",
+				Author:      db.HumansAuthor,
+				AuthorRef:   validHumanAuthorRef,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "invalid source ID format",
+		},
+		{
+			name: "missing workspace",
+			payload: WebhookActivityRequest{
+				ContentType: "general_update",
+				Content:     "Test content",
+				Author:      db.HumansAuthor,
+				AuthorRef:   validHumanAuthorRef,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "workspace is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payloadBytes, err := json.Marshal(tt.payload)
+			assert.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/activities/receive", bytes.NewReader(payloadBytes))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			ah.ReceiveActivity(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			var response WebhookResponse
+			err = json.NewDecoder(w.Body).Decode(&response)
+			assert.NoError(t, err)
+
+			if tt.expectedError != "" {
+				assert.False(t, response.Success)
+				assert.Equal(t, tt.expectedError, response.Error)
+			} else if tt.validateFunc != nil {
+				tt.validateFunc(t, response)
+			}
+		})
+	}
+}
+
+func TestReceiveActivity_InvalidJSON(t *testing.T) {
+	teardownSuite := SetupSuite(t)
+	defer teardownSuite(t)
+
+	ah := NewActivityHandler(&http.Client{}, db.TestDB)
+
+	req := httptest.NewRequest(http.MethodPost, "/activities/receive", bytes.NewReader([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	ah.ReceiveActivity(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response WebhookResponse
+	err := json.NewDecoder(w.Body).Decode(&response)
+	assert.NoError(t, err)
+	assert.False(t, response.Success)
+	assert.Equal(t, "Invalid request payload", response.Error)
+}

--- a/routes/activity_routes.go
+++ b/routes/activity_routes.go
@@ -17,6 +17,7 @@ func ActivityRoutes() chi.Router {
 		r.Get("/{id}", activityHandler.GetActivity)
 		r.Get("/thread/{thread_id}", activityHandler.GetActivitiesByThread)
 		r.Get("/thread/{thread_id}/latest", activityHandler.GetLatestActivityByThread)
+		r.Post("/receive", activityHandler.ReceiveActivity)
 	})
 
 	r.Group(func(r chi.Router) {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

-https://community.sphinx.chat/p/csb4dj2tu2rqjmn086qg/assigned/3653/0

## Demo:

https://www.loom.com/share/bb27beffb2cf4edab5e9bd60e876c22d

` Show video evidence of activity creation using no thread ID (this would be a new activity).`
 
![image](https://github.com/user-attachments/assets/7e4d63d0-582d-4953-9970-c8e3108f3376)

 `Show video evidence of activity creation with an existing thread ID included (this would be a response to a previous activity).`
 
![image](https://github.com/user-attachments/assets/f6767ca2-4ea7-4667-8ff3-7ece18657c44)

`DB:`

![image](https://github.com/user-attachments/assets/ffdee7e3-226f-4a96-88db-a2ea31c7bc67)

## Unit Test:

![image](https://github.com/user-attachments/assets/9cc11b1d-4da0-4f2a-8d6e-b70c938eb085)

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [ ] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend