### PR TITLE
feat: Add Quick Bounties and Quick Tickets endpoints for Feature view

### DIFF
--- a/db/interface.go
+++ b/db/interface.go
@@ -308,4 +308,6 @@ type Database interface {
 	DeleteActivity(id string) error
 	BuildTicketArray(groupIDs []string) []TicketArrayItem
 	GetBountiesByWorkspaceAndTimeRange(workspaceId string, startDate time.Time, endDate time.Time) ([]NewBounty, error)
+	GetBountiesByFeatureUuid(featureUuid string) ([]NewBounty, error)
+	GetTicketsByFeatureUUID(featureUuid string) ([]Tickets, error)
 }

--- a/db/structs.go
+++ b/db/structs.go
@@ -1340,6 +1340,34 @@ type NodeData struct {
 	Description string `json:"description"`
 }
 
+type QuickBountyItem struct {
+    BountyID      uint          `json:"bountyID"`
+    BountyTitle   string        `json:"bountyTitle"`
+    Status        BountyStatus  `json:"status"`
+    AssignedAlias *string       `json:"assignedAlias"`
+    PhaseID       *string       `json:"phaseID"`
+}
+
+type QuickBountiesResponse struct {
+    FeatureID string                       `json:"featureID"`
+    Phases    map[string][]QuickBountyItem `json:"phases"`    
+    Unphased  []QuickBountyItem            `json:"unphased"`
+}
+
+type QuickTicketItem struct {
+    TicketUUID    uuid.UUID    `json:"ticketUUID"`
+    TicketTitle   string       `json:"ticketTitle"`
+    Status        BountyStatus   `json:"status"`
+    AssignedAlias *string      `json:"assignedAlias"`
+    PhaseID       *string      `json:"phaseID"`
+}
+
+type QuickTicketsResponse struct {
+    FeatureID string                       `json:"featureID"`
+    Phases    map[string][]QuickTicketItem `json:"phases"`    
+    Unphased  []QuickTicketItem            `json:"unphased"`
+}
+
 type Node struct {
 	NodeType string   `json:"node_type"`
 	NodeData NodeData `json:"node_data"`

--- a/handlers/features.go
+++ b/handlers/features.go
@@ -911,12 +911,19 @@ func (oh *featureHandler) GetQuickBounties(w http.ResponseWriter, r *http.Reques
 		}
 
 		status := calculateBountyStatus(bounty)
+		
+		var phaseID *string
+		if bounty.PhaseUuid != "" {
+			phaseUUID := bounty.PhaseUuid
+			phaseID = &phaseUUID
+		}
+
 		item := db.QuickBountyItem{
 			BountyID:      bounty.ID,
 			BountyTitle:   bounty.Title,
 			Status:        status,
 			AssignedAlias: assignedAlias,
-			PhaseID:       &bounty.PhaseUuid,
+			PhaseID:       phaseID, 
 		}
 
 		if status == db.StatusTodo {
@@ -971,12 +978,18 @@ func (oh *featureHandler) GetQuickTickets(w http.ResponseWriter, r *http.Request
 	}
 
 	for _, ticket := range tickets {
+		var phaseID *string
+		if ticket.PhaseUUID != "" {
+			phaseUUID := ticket.PhaseUUID
+			phaseID = &phaseUUID
+		}
+
 		item := db.QuickTicketItem{
 			TicketUUID:    ticket.UUID,
 			TicketTitle:   ticket.Name,
 			Status:        db.StatusDraft,
 			AssignedAlias: nil,
-			PhaseID:       &ticket.PhaseUUID,
+			PhaseID:       phaseID,
 		}
 
 		if ticket.PhaseUUID != "" {

--- a/handlers/features.go
+++ b/handlers/features.go
@@ -864,3 +864,128 @@ func (oh *featureHandler) UpdateFeatureStatus(w http.ResponseWriter, r *http.Req
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(updatedFeature)
 }
+
+func (oh *featureHandler) GetQuickBounties(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
+	if pubKeyFromAuth == "" {
+		logger.Log.Info("no pubkey from auth")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	featureUUID := chi.URLParam(r, "feature_uuid")
+	if featureUUID == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "feature_uuid is required"})
+		return
+	}
+
+	feature := oh.db.GetFeatureByUuid(featureUUID)
+	if feature.ID == 0 {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "feature not found"})
+		return
+	}
+
+	bounties, err := oh.db.GetBountiesByFeatureUuid(featureUUID)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	response := db.QuickBountiesResponse{
+		FeatureID: featureUUID,
+		Phases:    make(map[string][]db.QuickBountyItem),
+		Unphased:  make([]db.QuickBountyItem, 0),
+	}
+
+	for _, bounty := range bounties {
+		var assignedAlias *string
+		if bounty.Assignee != "" {
+			assignee := oh.db.GetPersonByPubkey(bounty.Assignee)
+			if assignee.OwnerAlias != "" {
+				assignedAlias = &assignee.OwnerAlias
+			}
+		}
+
+		status := calculateBountyStatus(bounty)
+		item := db.QuickBountyItem{
+			BountyID:      bounty.ID,
+			BountyTitle:   bounty.Title,
+			Status:        status,
+			AssignedAlias: assignedAlias,
+			PhaseID:       &bounty.PhaseUuid,
+		}
+
+		if status == db.StatusTodo {
+			item.AssignedAlias = nil
+		}
+
+		if bounty.PhaseUuid != "" {
+			response.Phases[bounty.PhaseUuid] = append(response.Phases[bounty.PhaseUuid], item)
+		} else {
+			response.Unphased = append(response.Unphased, item)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+func (oh *featureHandler) GetQuickTickets(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
+	if pubKeyFromAuth == "" {
+		logger.Log.Info("no pubkey from auth")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	featureUUID := chi.URLParam(r, "feature_uuid")
+	if featureUUID == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "feature_uuid is required"})
+		return
+	}
+
+	feature := oh.db.GetFeatureByUuid(featureUUID)
+	if feature.ID == 0 {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "feature not found"})
+		return
+	}
+
+	tickets, err := oh.db.GetTicketsByFeatureUUID(featureUUID)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	response := db.QuickTicketsResponse{
+		FeatureID: featureUUID,
+		Phases:    make(map[string][]db.QuickTicketItem),
+		Unphased:  make([]db.QuickTicketItem, 0),
+	}
+
+	for _, ticket := range tickets {
+		item := db.QuickTicketItem{
+			TicketUUID:    ticket.UUID,
+			TicketTitle:   ticket.Name,
+			Status:        db.StatusDraft,
+			AssignedAlias: nil,
+			PhaseID:       &ticket.PhaseUUID,
+		}
+
+		if ticket.PhaseUUID != "" {
+			response.Phases[ticket.PhaseUUID] = append(response.Phases[ticket.PhaseUUID], item)
+		} else {
+			response.Unphased = append(response.Unphased, item)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}

--- a/handlers/features_test.go
+++ b/handlers/features_test.go
@@ -2030,7 +2030,7 @@ func TestGetStoryByUuid(t *testing.T) {
 
 	feature := db.WorkspaceFeatures{
 		Uuid:          uuid.New().String(),
-			WorkspaceUuid: workspace.Uuid,
+		WorkspaceUuid: workspace.Uuid,
 		Name:          "test-feature",
 		Url:           "https://github.com/test-feature",
 		Priority:      0,
@@ -2089,139 +2089,139 @@ func TestGetStoryByUuid(t *testing.T) {
 
 	t.Run("Valid Request with Existing Story", func(t *testing.T) {
 		rr := httptest.NewRecorder()
-        handler := http.HandlerFunc(fHandler.GetStoryByUuid)
-
-        rctx := chi.NewRouteContext()
-        rctx.URLParams.Add("feature_uuid", feature.Uuid)
-        rctx.URLParams.Add("story_uuid", featureStory.Uuid)
-        ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
-        req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx), 
-            http.MethodGet, "/features/"+feature.Uuid+"/story/"+featureStory.Uuid, nil)
-        assert.NoError(t, err)
-
-        handler.ServeHTTP(rr, req)
-
-        assert.Equal(t, http.StatusOK, rr.Code)
-        var returnedStory db.FeatureStory
-        err = json.Unmarshal(rr.Body.Bytes(), &returnedStory)
-        assert.NoError(t, err)
-        assert.Equal(t, featureStory.Description, returnedStory.Description)
-    })
-
-    t.Run("Valid Request with Non-Existing Story", func(t *testing.T) {
-        rr := httptest.NewRecorder()
-        handler := http.HandlerFunc(fHandler.GetStoryByUuid)
-
-        nonExistentUUID := uuid.New().String()
-		rctx := chi.NewRouteContext()
-        rctx.URLParams.Add("feature_uuid", feature.Uuid)
-        rctx.URLParams.Add("story_uuid", nonExistentUUID)
-        ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
-        req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
-            http.MethodGet, "/features/"+feature.Uuid+"/story/"+nonExistentUUID, nil)
-        assert.NoError(t, err)
-
-        handler.ServeHTTP(rr, req)
-        assert.Equal(t, http.StatusNotFound, rr.Code)
-    })
-
-    t.Run("Valid Request with Empty UUIDs", func(t *testing.T) {
-		rr := httptest.NewRecorder()
-        handler := http.HandlerFunc(fHandler.GetStoryByUuid)
-
-        rctx := chi.NewRouteContext()
-        rctx.URLParams.Add("feature_uuid", "")
-        rctx.URLParams.Add("story_uuid", "")
-        ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
-        req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
-            http.MethodGet, "/features//story/", nil)
-		assert.NoError(t, err)
-
-        handler.ServeHTTP(rr, req)
-        assert.Equal(t, http.StatusNotFound, rr.Code)
-    })
-
-    t.Run("Unauthorized Request", func(t *testing.T) {
-        rr := httptest.NewRecorder()
-        handler := http.HandlerFunc(fHandler.GetStoryByUuid)
-
-        rctx := chi.NewRouteContext()
-        rctx.URLParams.Add("feature_uuid", feature.Uuid)
-        rctx.URLParams.Add("story_uuid", featureStory.Uuid)
-        req, err := http.NewRequestWithContext(context.WithValue(context.Background(), chi.RouteCtxKey, rctx),
-            http.MethodGet, "/features/"+feature.Uuid+"/story/"+featureStory.Uuid, nil)
-        assert.NoError(t, err)
-
-        handler.ServeHTTP(rr, req)
-        assert.Equal(t, http.StatusUnauthorized, rr.Code)
-    })
-
-    t.Run("Invalid UUID Format", func(t *testing.T) {
-        rr := httptest.NewRecorder()
-        handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+		handler := http.HandlerFunc(fHandler.GetStoryByUuid)
 
 		rctx := chi.NewRouteContext()
-        rctx.URLParams.Add("feature_uuid", "invalid-uuid")
-        rctx.URLParams.Add("story_uuid", "invalid-uuid")
-        ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
-        req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
-            http.MethodGet, "/features/invalid-uuid/story/invalid-uuid", nil)
-        assert.NoError(t, err)
-
-        handler.ServeHTTP(rr, req)
-        assert.Equal(t, http.StatusNotFound, rr.Code)
-    })
-	
-    t.Run("Story with Special Characters", func(t *testing.T) {
-		rr := httptest.NewRecorder()
-        handler := http.HandlerFunc(fHandler.GetStoryByUuid)
-
-        specialCharsUUID := "!@#$%^&*()"
-        rctx := chi.NewRouteContext()
-        rctx.URLParams.Add("feature_uuid", feature.Uuid)
-        rctx.URLParams.Add("story_uuid", specialCharsUUID)
-        ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
-        req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
-            http.MethodGet, "/features/"+feature.Uuid+"/story/"+url.QueryEscape(specialCharsUUID), nil)
+		rctx.URLParams.Add("feature_uuid", feature.Uuid)
+		rctx.URLParams.Add("story_uuid", featureStory.Uuid)
+		ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+feature.Uuid+"/story/"+featureStory.Uuid, nil)
 		assert.NoError(t, err)
 
-        handler.ServeHTTP(rr, req)
-        assert.Equal(t, http.StatusNotFound, rr.Code)
-    })
+		handler.ServeHTTP(rr, req)
 
-    t.Run("Valid Request with Mixed Case UUIDs", func(t *testing.T) {
-        rr := httptest.NewRecorder()
-        handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		var returnedStory db.FeatureStory
+		err = json.Unmarshal(rr.Body.Bytes(), &returnedStory)
+		assert.NoError(t, err)
+		assert.Equal(t, featureStory.Description, returnedStory.Description)
+	})
 
-        upperFeatureUUID := strings.ToUpper(feature.Uuid)
-        upperStoryUUID := strings.ToUpper(featureStory.Uuid)
+	t.Run("Valid Request with Non-Existing Story", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+
+		nonExistentUUID := uuid.New().String()
 		rctx := chi.NewRouteContext()
-        rctx.URLParams.Add("feature_uuid", upperFeatureUUID)
-        rctx.URLParams.Add("story_uuid", upperStoryUUID)
-        ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
-        req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
-            http.MethodGet, "/features/"+upperFeatureUUID+"/story/"+upperStoryUUID, nil)
-        assert.NoError(t, err)
-
-        handler.ServeHTTP(rr, req)
-        assert.Equal(t, http.StatusNotFound, rr.Code)
-    })
-
-    t.Run("Request with Long UUIDs", func(t *testing.T) {
-		rr := httptest.NewRecorder()
-        handler := http.HandlerFunc(fHandler.GetStoryByUuid)
-
-        longUUID := feature.Uuid + "extra"
-        rctx := chi.NewRouteContext()
-        rctx.URLParams.Add("feature_uuid", longUUID)
-        rctx.URLParams.Add("story_uuid", longUUID)
-        ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
-        req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
-            http.MethodGet, "/features/"+longUUID+"/story/"+longUUID, nil)
+		rctx.URLParams.Add("feature_uuid", feature.Uuid)
+		rctx.URLParams.Add("story_uuid", nonExistentUUID)
+		ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+feature.Uuid+"/story/"+nonExistentUUID, nil)
 		assert.NoError(t, err)
 
-        handler.ServeHTTP(rr, req)
-        assert.Equal(t, http.StatusNotFound, rr.Code)
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("Valid Request with Empty UUIDs", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", "")
+		rctx.URLParams.Add("story_uuid", "")
+		ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features//story/", nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("Unauthorized Request", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", feature.Uuid)
+		rctx.URLParams.Add("story_uuid", featureStory.Uuid)
+		req, err := http.NewRequestWithContext(context.WithValue(context.Background(), chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+feature.Uuid+"/story/"+featureStory.Uuid, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("Invalid UUID Format", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", "invalid-uuid")
+		rctx.URLParams.Add("story_uuid", "invalid-uuid")
+		ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/invalid-uuid/story/invalid-uuid", nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("Story with Special Characters", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+
+		specialCharsUUID := "!@#$%^&*()"
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", feature.Uuid)
+		rctx.URLParams.Add("story_uuid", specialCharsUUID)
+		ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+feature.Uuid+"/story/"+url.QueryEscape(specialCharsUUID), nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("Valid Request with Mixed Case UUIDs", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+
+		upperFeatureUUID := strings.ToUpper(feature.Uuid)
+		upperStoryUUID := strings.ToUpper(featureStory.Uuid)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", upperFeatureUUID)
+		rctx.URLParams.Add("story_uuid", upperStoryUUID)
+		ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+upperFeatureUUID+"/story/"+upperStoryUUID, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("Request with Long UUIDs", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(fHandler.GetStoryByUuid)
+
+		longUUID := feature.Uuid + "extra"
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("feature_uuid", longUUID)
+		rctx.URLParams.Add("story_uuid", longUUID)
+		ctx := context.WithValue(context.Background(), auth.ContextKey, person.OwnerPubKey)
+		req, err := http.NewRequestWithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx),
+			http.MethodGet, "/features/"+longUUID+"/story/"+longUUID, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
 	})
 }
 
@@ -5149,4 +5149,496 @@ func TestBriefSend(t *testing.T) {
 
 		})
 	}
+}
+
+func TestGetQuickBounties(t *testing.T) {
+	teardownSuite := SetupSuite(t)
+	defer teardownSuite(t)
+
+	db.CleanTestData()
+	fHandler := NewFeatureHandler(db.TestDB)
+
+	now := time.Now()
+
+	person := db.Person{
+		Uuid:        uuid.New().String(),
+		OwnerPubKey: "testfeaturepubkey",
+		OwnerAlias:  "testfeaturealias",
+		Description: "testfeaturedescription",
+		Created:     &now,
+		Updated:     &now,
+		Deleted:     false,
+	}
+	db.TestDB.CreateOrEditPerson(person)
+
+	workspace := db.Workspace{
+		Uuid:        uuid.New().String(),
+		Name:        "Test tickets space",
+		OwnerPubKey: person.OwnerPubKey,
+		Created:     &now,
+		Updated:     &now,
+	}
+	db.TestDB.CreateOrEditWorkspace(workspace)
+
+	feature := db.WorkspaceFeatures{
+		Uuid:          uuid.New().String(),
+		WorkspaceUuid: workspace.Uuid,
+		Name:          "test",
+		Brief:         "test brief",
+		Requirements:  "Test requirements",
+		Architecture:  "Test architecture",
+		Url:           "Test url",
+		Priority:      1,
+		Created:       &now,
+		Updated:       &now,
+		CreatedBy:     person.OwnerPubKey,
+		UpdatedBy:     person.OwnerPubKey,
+	}
+
+	db.TestDB.CreateOrEditFeature(feature)
+
+	phase := db.FeaturePhase{
+		Uuid:        uuid.New().String(),
+		FeatureUuid: feature.Uuid,
+		Name:        "test feature phase",
+		Priority:    1,
+		Created:     &now,
+		Updated:     &now,
+	}
+
+	db.TestDB.CreateOrEditFeaturePhase(phase)
+
+	bounty := db.NewBounty{
+		OwnerID:       person.OwnerPubKey,
+		WorkspaceUuid: workspace.Uuid,
+		FeatureUuid:   feature.Uuid,
+		Title:         "test-bounty",
+		PhaseUuid:     phase.Uuid,
+		Description:   "test-description",
+		Price:         1000,
+		Type:          "coding_task",
+		Assignee:      "",
+		Show:          true,
+	}
+
+	db.TestDB.CreateOrEditBounty(bounty)
+
+	t.Run("should return 401 if not authorized", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+feature.Uuid+"/quick-bounties", nil)
+
+		fHandler.GetQuickBounties(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("should return 400 if feature UUID is empty", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features//quick-bounties", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", "")
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickBounties(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("should return 404 if feature not found", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		nonExistentUUID := uuid.New().String()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+nonExistentUUID+"/quick-bounties", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", nonExistentUUID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickBounties(rr, req)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("should return correct response for without assigned bounty", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+feature.Uuid+"/quick-bounties", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", feature.Uuid)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickBounties(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response db.QuickBountiesResponse
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		assert.NoError(t, err)
+
+		t.Logf("Response: %+v", response)
+		t.Logf("Feature UUID: %s", feature.Uuid)
+		t.Logf("Phase UUID: %s", phase.Uuid)
+
+		assert.Equal(t, feature.Uuid, response.FeatureID)
+		assert.NotNil(t, response.Phases)
+		assert.NotNil(t, response.Unphased)
+
+		phaseBounties, exists := response.Phases[phase.Uuid]
+		assert.True(t, exists, "Phase %s should exist in response", phase.Uuid)
+		assert.Len(t, phaseBounties, 1, "Should have 1 bounty in phase")
+		if exists && len(phaseBounties) > 0 {
+			assert.Equal(t, bounty.Title, phaseBounties[0].BountyTitle)
+			assert.Equal(t, db.StatusTodo, phaseBounties[0].Status, "Bounty status should match")
+			assert.Nil(t, phaseBounties[0].AssignedAlias)
+		}
+	})
+
+	t.Run("should return correct response for assigned bounty", func(t *testing.T) {
+
+		assignedBounty := db.NewBounty{
+			OwnerID:       person.OwnerPubKey,
+			WorkspaceUuid: workspace.Uuid,
+			FeatureUuid:   feature.Uuid,
+			Title:         "assigned-bounty",
+			PhaseUuid:     phase.Uuid,
+			Description:   "test-description",
+			Price:         1000,
+			Type:          "coding_task",
+			Assignee:      person.OwnerPubKey,
+			Show:          true,
+		}
+		db.TestDB.CreateOrEditBounty(assignedBounty)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+feature.Uuid+"/quick-bounties", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", feature.Uuid)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickBounties(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response db.QuickBountiesResponse
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		assert.NoError(t, err)
+
+		t.Logf("Response for assigned bounty: %+v", response)
+
+		phaseBounties, exists := response.Phases[phase.Uuid]
+		assert.True(t, exists, "Phase %s should exist in response", phase.Uuid)
+		assert.Equal(t, 1, len(phaseBounties), "Should have exactly 1 bounty in phase")
+
+		bounty := phaseBounties[0]
+		assert.Equal(t, "assigned-bounty", bounty.BountyTitle)
+		assert.Equal(t, db.StatusInProgress, bounty.Status, "Bounty with assignee should have InProgress status")
+		assert.NotNil(t, bounty.AssignedAlias, "Bounty should have assigned alias")
+		assert.Equal(t, person.OwnerAlias, *bounty.AssignedAlias, "Bounty should have correct alias")
+	})
+
+	t.Run("should handle feature with empty phases", func(t *testing.T) {
+
+		featureEmptyPhase := db.WorkspaceFeatures{
+			Uuid:          uuid.New().String(),
+			WorkspaceUuid: workspace.Uuid,
+			Name:          "test-empty-phase",
+			Brief:         "test brief",
+			Requirements:  "Test requirements",
+			Architecture:  "Test architecture",
+			Url:           "Test url",
+			Priority:      1,
+			Created:       &now,
+			Updated:       &now,
+			CreatedBy:     person.OwnerPubKey,
+			UpdatedBy:     person.OwnerPubKey,
+		}
+		db.TestDB.CreateOrEditFeature(featureEmptyPhase)
+
+		emptyPhase := db.FeaturePhase{
+			Uuid:        uuid.New().String(),
+			FeatureUuid: featureEmptyPhase.Uuid,
+			Name:        "empty phase",
+			Priority:    1,
+			Created:     &now,
+			Updated:     &now,
+		}
+		db.TestDB.CreateOrEditFeaturePhase(emptyPhase)
+
+		bountyNoPhase := db.NewBounty{
+			OwnerID:       person.OwnerPubKey,
+			WorkspaceUuid: workspace.Uuid,
+			FeatureUuid:   featureEmptyPhase.Uuid,
+			Title:         "bounty-no-phase",
+			Description:   "test-description",
+			Price:         1000,
+			Type:          "coding_task",
+			Show:          true,
+			PhaseUuid:     "",
+		}
+
+		db.TestDB.CreateOrEditBounty(bountyNoPhase)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+featureEmptyPhase.Uuid+"/quick-bounties", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", featureEmptyPhase.Uuid)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickBounties(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response db.QuickBountiesResponse
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		assert.NoError(t, err)
+
+		assert.Equal(t, featureEmptyPhase.Uuid, response.FeatureID)
+		assert.Empty(t, response.Phases[emptyPhase.Uuid], "Phase should be empty")
+		assert.Empty(t, response.Unphased, "Unphased should be empty")
+	})
+
+	t.Run("should handle invalid feature UUID format", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features/invalid-uuid/quick-bounties", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", "invalid-uuid")
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickBounties(rr, req)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code, "Should return 404 for invalid UUID")
+
+		var response map[string]string
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		assert.NoError(t, err)
+		assert.Equal(t, "feature not found", response["error"], "Should return feature not found error")
+
+		t.Logf("Response: %+v", response)
+		t.Logf("Status Code: %d", rr.Code)
+	})
+
+	t.Run("should handle empty feature UUID", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features//quick-bounties", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", "")
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickBounties(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code, "Should return 400 for empty UUID")
+
+		var response map[string]string
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		assert.NoError(t, err)
+		assert.Equal(t, "feature_uuid is required", response["error"], "Should return UUID required error")
+	})
+}
+
+func TestGetQuickTickets(t *testing.T) {
+	teardownSuite := SetupSuite(t)
+	defer teardownSuite(t)
+
+	db.CleanTestData()
+
+	fHandler := NewFeatureHandler(db.TestDB)
+	now := time.Now()
+
+	person := db.Person{
+		Uuid:        uuid.New().String(),
+		OwnerPubKey: "testticketpubkey",
+		OwnerAlias:  "testticketalias",
+		Description: "testticketdescription",
+		Created:     &now,
+		Updated:     &now,
+		Deleted:     false,
+	}
+	db.TestDB.CreateOrEditPerson(person)
+
+	workspace := db.Workspace{
+		Uuid:        uuid.New().String(),
+		Name:        "Test tickets space",
+		OwnerPubKey: person.OwnerPubKey,
+		Created:     &now,
+		Updated:     &now,
+	}
+	db.TestDB.CreateOrEditWorkspace(workspace)
+
+	feature := db.WorkspaceFeatures{
+		Uuid:          uuid.New().String(),
+		WorkspaceUuid: workspace.Uuid,
+		Name:          "test feature",
+		Brief:         "test brief",
+		Requirements:  "Test requirements",
+		Architecture:  "Test architecture",
+		Url:           "Test url",
+		Priority:      1,
+		Created:       &now,
+		Updated:       &now,
+		CreatedBy:     person.OwnerPubKey,
+		UpdatedBy:     person.OwnerPubKey,
+	}
+	db.TestDB.CreateOrEditFeature(feature)
+
+	phase := db.FeaturePhase{
+		Uuid:        uuid.New().String(),
+		FeatureUuid: feature.Uuid,
+		Name:        "test phase",
+		Priority:    1,
+		Created:     &now,
+		Updated:     &now,
+	}
+	db.TestDB.CreateOrEditFeaturePhase(phase)
+
+	t.Run("should return 401 if no auth", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+feature.Uuid+"/quick-tickets", nil)
+
+		fHandler.GetQuickTickets(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("should return 400 if feature UUID is empty", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features//quick-tickets", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", "")
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickTickets(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var response map[string]string
+		json.NewDecoder(rr.Body).Decode(&response)
+		assert.Equal(t, "feature_uuid is required", response["error"])
+	})
+
+	t.Run("should return 404 if feature not found", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		nonExistentUUID := uuid.New().String()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+nonExistentUUID+"/quick-tickets", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", nonExistentUUID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickTickets(rr, req)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+
+		var response map[string]string
+		json.NewDecoder(rr.Body).Decode(&response)
+		assert.Equal(t, "feature not found", response["error"])
+	})
+
+	t.Run("should return correct response for feature with no tickets", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+feature.Uuid+"/quick-tickets", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", feature.Uuid)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickTickets(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response db.QuickTicketsResponse
+		err := json.NewDecoder(rr.Body).Decode(&response)
+		assert.NoError(t, err)
+
+		assert.Equal(t, feature.Uuid, response.FeatureID)
+		assert.Empty(t, response.Phases)
+		assert.Empty(t, response.Unphased)
+	})
+
+	t.Run("should return correct response for feature with phased ticket", func(t *testing.T) {
+
+		ticketUUID := uuid.New()
+		ticket := db.Tickets{
+			UUID:        ticketUUID,
+			FeatureUUID: feature.Uuid,
+			PhaseUUID:   phase.Uuid,
+			Name:        "test phased ticket",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		_, err := db.TestDB.CreateOrEditTicket(&ticket)
+		assert.NoError(t, err)
+
+		savedTicket, err := db.TestDB.GetTicket(ticketUUID.String())
+		assert.NoError(t, err)
+		assert.Equal(t, ticket.Name, savedTicket.Name)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/features/"+feature.Uuid+"/quick-tickets", nil)
+
+		ctx := context.WithValue(req.Context(), auth.ContextKey, person.OwnerPubKey)
+		req = req.WithContext(ctx)
+
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("feature_uuid", feature.Uuid)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+
+		fHandler.GetQuickTickets(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response db.QuickTicketsResponse
+		err = json.NewDecoder(rr.Body).Decode(&response)
+		assert.NoError(t, err)
+
+		t.Logf("Ticket UUID: %s", ticketUUID.String())
+		t.Logf("Response: %+v", response)
+
+		assert.Equal(t, feature.Uuid, response.FeatureID)
+		phasedTickets, exists := response.Phases[phase.Uuid]
+		assert.True(t, exists, "Phase should exist in response")
+		assert.Len(t, phasedTickets, 1, "Should have 1 ticket in phase")
+		assert.Empty(t, response.Unphased, "Should have no unphased tickets")
+
+		if len(phasedTickets) > 0 {
+			assert.Equal(t, ticket.Name, phasedTickets[0].TicketTitle, "Ticket title should match")
+			assert.Equal(t, db.StatusDraft, phasedTickets[0].Status, "Ticket status should be draft")
+			assert.Nil(t, phasedTickets[0].AssignedAlias, "Ticket should not have assigned alias")
+			assert.Equal(t, phase.Uuid, *phasedTickets[0].PhaseID, "Phase ID should match")
+		}
+	})
 }

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -15156,3 +15156,115 @@ func (_c *Database_BuildTicketArray_Call) RunAndReturn(run func([]string) []db.T
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetBountiesByFeatureUuid provides a mock function with given fields: featureUuid
+func (_m *Database) GetBountiesByFeatureUuid(featureUuid string) ([]db.NewBounty, error) {
+	ret := _m.Called(featureUuid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBountiesByFeatureUuid")
+	}
+
+	var r0 []db.NewBounty
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]db.NewBounty, error)); ok {
+		return rf(featureUuid)
+	}
+	if rf, ok := ret.Get(0).(func(string) []db.NewBounty); ok {
+		r0 = rf(featureUuid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.NewBounty)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(featureUuid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetBountiesByFeatureUuid_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) GetBountiesByFeatureUuid(featureUuid interface{}) *Database_GetBountiesByFeatureUuid_Call {
+	return &Database_GetBountiesByFeatureUuid_Call{Call: _e.mock.On("GetBountiesByFeatureUuid", featureUuid)}
+}
+
+func (_c *Database_GetBountiesByFeatureUuid_Call) Run(run func(featureUuid string)) *Database_GetBountiesByFeatureUuid_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_GetBountiesByFeatureUuid_Call) Return(_a0 []db.NewBounty, _a1 error) *Database_GetBountiesByFeatureUuid_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetBountiesByFeatureUuid_Call) RunAndReturn(run func(string) ([]db.NewBounty, error)) *Database_GetBountiesByFeatureUuid_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+
+// GetTicketsByFeatureUUID provides a mock function with given fields: featureUuid
+func (_m *Database) GetTicketsByFeatureUUID(featureUuid string) ([]db.Tickets, error) {
+	ret := _m.Called(featureUuid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTicketsByFeatureUUID")
+	}
+
+	var r0 []db.Tickets
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]db.Tickets, error)); ok {
+		return rf(featureUuid)
+	}
+	if rf, ok := ret.Get(0).(func(string) []db.Tickets); ok {
+		r0 = rf(featureUuid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.Tickets)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(featureUuid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type Database_GetTicketsByFeatureUUID_Call struct {
+	*mock.Call
+}
+
+func (_e *Database_Expecter) GetTicketsByFeatureUUID(featureUuid interface{}) *Database_GetTicketsByFeatureUUID_Call {
+	return &Database_GetTicketsByFeatureUUID_Call{Call: _e.mock.On("GetTicketsByFeatureUUID", featureUuid)}
+}
+
+func (_c *Database_GetTicketsByFeatureUUID_Call) Run(run func(featureUuid string)) *Database_GetTicketsByFeatureUUID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_GetTicketsByFeatureUUID_Call) Return(_a0 []db.Tickets, _a1 error) *Database_GetTicketsByFeatureUUID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetTicketsByFeatureUUID_Call) RunAndReturn(run func(string) ([]db.Tickets, error)) *Database_GetTicketsByFeatureUUID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+

--- a/routes/features.go
+++ b/routes/features.go
@@ -41,6 +41,8 @@ func FeatureRoutes() chi.Router {
 		r.Delete("/{feature_uuid}/story/{story_uuid}", featureHandlers.DeleteStory)
 		r.Get("/{feature_uuid}/phase/{phase_uuid}/bounty", featureHandlers.GetBountiesByFeatureAndPhaseUuid)
 		r.Get("/{feature_uuid}/phase/{phase_uuid}/bounty/count", featureHandlers.GetBountiesCountByFeatureAndPhaseUuid)
+		r.Get("/{feature_uuid}/quick-bounties", featureHandlers.GetQuickBounties)
+		r.Get("/{feature_uuid}/quick-tickets", featureHandlers.GetQuickTickets)
 
 	})
 	return r


### PR DESCRIPTION
### Describe the Changes:
- Added new endpoints to fetch phase-grouped bounties and tickets data for feature view with optimized response structure.

Daily Bounty Challenge: https://community.sphinx.chat/bounty/3761

## Issue ticket number and link:
- **Bounty Number:** [ 3761 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3761](url) ]

### Evidence:

#### `Loom:`

https://www.loom.com/share/9d241563b0b643d9a335d83c66fbec29

![image](https://github.com/user-attachments/assets/b8335c3d-627e-4fda-9d52-16c4e5d1a0ed)

![image](https://github.com/user-attachments/assets/025ea879-a45a-4686-9fbb-51bfad439d0e)

#### `Unit Test:`

![image](https://github.com/user-attachments/assets/5a0c98be-72c4-4720-a77c-ca4488174b3c)

![image](https://github.com/user-attachments/assets/840439c3-3008-4312-87e3-a60b4034fd06)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR