### PR TITLE
feat: added session id when calling /invite endpoint

### DIFF
--- a/handlers/auth_test.go
+++ b/handlers/auth_test.go
@@ -742,7 +742,7 @@ func TestCreateConnectionCode(t *testing.T) {
 
 	aHandler := NewAuthHandler(db.TestDB)
 
-	aHandler.makeConnectionCodeRequest = func(inviter_pubkey string, inviter_route_hint string, msats_amount uint64) string {
+	aHandler.makeConnectionCodeRequest = func(inviter_pubkey string, inviter_route_hint string, msats_amount uint64, sessionId string) string {
 		return "22222222222222222"
 	}
 


### PR DESCRIPTION
## Describe your changes
This is attempting to pass the correct session_id to the v2 bot so we can link payments from the frontend to the payment bot
## Issue ticket number and link
https://github.com/stakwork/sphinx-tribes/issues/2502
## Type of change
logging

Still need to add the other endpoint calls but opening this up as a draft