### PR TITLE
 Fix: Return Latest Ticket for Each Ticket Group in Quick Tickets Endpoint

### DIFF
--- a/handlers/features.go
+++ b/handlers/features.go
@@ -977,6 +977,8 @@ func (oh *featureHandler) GetQuickTickets(w http.ResponseWriter, r *http.Request
 		Unphased:  make([]db.QuickTicketItem, 0),
 	}
 
+	latestTickets := make(map[string]db.QuickTicketItem)
+
 	for _, ticket := range tickets {
 		var phaseID *string
 		if ticket.PhaseUUID != "" {
@@ -992,8 +994,14 @@ func (oh *featureHandler) GetQuickTickets(w http.ResponseWriter, r *http.Request
 			PhaseID:       phaseID,
 		}
 
-		if ticket.PhaseUUID != "" {
-			response.Phases[ticket.PhaseUUID] = append(response.Phases[ticket.PhaseUUID], item)
+		if existingItem, exists := latestTickets[ticket.TicketGroup.String()]; !exists || ticket.UUID.String() > existingItem.TicketUUID.String() {
+			latestTickets[ticket.TicketGroup.String()] = item
+		}
+	}
+
+	for _, item := range latestTickets {
+		if item.PhaseID != nil {
+			response.Phases[*item.PhaseID] = append(response.Phases[*item.PhaseID], item)
 		} else {
 			response.Unphased = append(response.Unphased, item)
 		}

--- a/handlers/features_test.go
+++ b/handlers/features_test.go
@@ -5592,13 +5592,17 @@ func TestGetQuickTickets(t *testing.T) {
 	t.Run("should return correct response for feature with phased ticket", func(t *testing.T) {
 
 		ticketUUID := uuid.New()
+		ticketGroupUUID := uuid.New()
+
 		ticket := db.Tickets{
-			UUID:        ticketUUID,
-			FeatureUUID: feature.Uuid,
-			PhaseUUID:   phase.Uuid,
-			Name:        "test phased ticket",
-			CreatedAt:   now,
-			UpdatedAt:   now,
+			UUID:          ticketUUID,
+			TicketGroup:   &ticketGroupUUID,
+			FeatureUUID:   feature.Uuid,
+			PhaseUUID:     phase.Uuid,
+			Name:          "test phased ticket",
+			CreatedAt:     now,
+			UpdatedAt:     now,
+			Version:       1,
 		}
 		_, err := db.TestDB.CreateOrEditTicket(&ticket)
 		assert.NoError(t, err)
@@ -5606,6 +5610,7 @@ func TestGetQuickTickets(t *testing.T) {
 		savedTicket, err := db.TestDB.GetTicket(ticketUUID.String())
 		assert.NoError(t, err)
 		assert.Equal(t, ticket.Name, savedTicket.Name)
+		assert.Equal(t, ticketGroupUUID, *savedTicket.TicketGroup)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/features/"+feature.Uuid+"/quick-tickets", nil)
@@ -5626,6 +5631,7 @@ func TestGetQuickTickets(t *testing.T) {
 		assert.NoError(t, err)
 
 		t.Logf("Ticket UUID: %s", ticketUUID.String())
+		t.Logf("Ticket Group UUID: %s", ticketGroupUUID.String())
 		t.Logf("Response: %+v", response)
 
 		assert.Equal(t, feature.Uuid, response.FeatureID)


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

- https://community.sphinx.chat/p/cs7n8c2tu2rivj8gup0g/bounties/3790/4

## Type of change

https://www.loom.com/share/ba58990d8ae648e5a12cca5a5ab79df2

![image](https://github.com/user-attachments/assets/d072805c-57aa-47d9-897e-960564a5b111)

![image](https://github.com/user-attachments/assets/096f1ed2-c55a-41a4-85e8-bc1316cd7e85)

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [ ] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend