### PR TITLE
Add `Pagination` Support for Chat History Retrieval and `Unit Tests`

### DIFF
--- a/db/interface.go
+++ b/db/interface.go
@@ -213,7 +213,7 @@ type Database interface {
 	AddChatMessage(message *ChatMessage) (ChatMessage, error)
 	UpdateChatMessage(message *ChatMessage) (ChatMessage, error)
 	GetChatMessagesForChatID(chatID string) ([]ChatMessage, error)
-	GetChatsForWorkspace(workspaceID string, chatStatus string) ([]Chat, error)
+	GetChatsForWorkspace(workspaceID string, chatStatus string, limit int, offset int) ([]Chat, int64, error)
 	GetCodeGraphByUUID(uuid string) (WorkspaceCodeGraph, error)
 	GetCodeGraphByWorkspaceUuid(workspace_uuid string) (WorkspaceCodeGraph, error)
 	CreateOrEditCodeGraph(m WorkspaceCodeGraph) (WorkspaceCodeGraph, error)

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -6171,61 +6171,64 @@ func (_c *Database_GetChatMessagesForChatID_Call) RunAndReturn(run func(string) 
 	return _c
 }
 
-// GetChatsForWorkspace provides a mock function with given fields: workspaceID, chatStatus
-func (_m *Database) GetChatsForWorkspace(workspaceID string, chatStatus string) ([]db.Chat, error) {
-	ret := _m.Called(workspaceID, chatStatus)
+// GetChatsForWorkspace provides a mock function with given fields: workspaceID, chatStatus, limit, offset
+func (_m *Database) GetChatsForWorkspace(workspaceID string, chatStatus string, limit int, offset int) ([]db.Chat, int64, error) {
+	ret := _m.Called(workspaceID, chatStatus, limit, offset)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetChatsForWorkspace")
 	}
 
 	var r0 []db.Chat
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) ([]db.Chat, error)); ok {
-		return rf(workspaceID, chatStatus)
+	var r1 int64
+	var r2 error
+	if rf, ok := ret.Get(0).(func(string, string, int, int) ([]db.Chat, int64, error)); ok {
+		return rf(workspaceID, chatStatus, limit, offset)
 	}
-	if rf, ok := ret.Get(0).(func(string, string) []db.Chat); ok {
-		r0 = rf(workspaceID, chatStatus)
+	if rf, ok := ret.Get(0).(func(string, string, int, int) []db.Chat); ok {
+		r0 = rf(workspaceID, chatStatus, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]db.Chat)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(workspaceID, chatStatus)
+	if rf, ok := ret.Get(1).(func(string, string, int, int) int64); ok {
+		r1 = rf(workspaceID, chatStatus, limit, offset)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int64)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(string, string, int, int) error); ok {
+		r2 = rf(workspaceID, chatStatus, limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
-// Database_GetChatsForWorkspace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetChatsForWorkspace'
 type Database_GetChatsForWorkspace_Call struct {
 	*mock.Call
 }
 
-// GetChatsForWorkspace is a helper method to define mock.On call
-//   - workspaceID string
-//   - chatStatus string
-func (_e *Database_Expecter) GetChatsForWorkspace(workspaceID interface{}, chatStatus interface{}) *Database_GetChatsForWorkspace_Call {
-	return &Database_GetChatsForWorkspace_Call{Call: _e.mock.On("GetChatsForWorkspace", workspaceID, chatStatus)}
+func (_e *Database_Expecter) GetChatsForWorkspace(workspaceID interface{}, chatStatus interface{}, limit interface{}, offset interface{}) *Database_GetChatsForWorkspace_Call {
+	return &Database_GetChatsForWorkspace_Call{Call: _e.mock.On("GetChatsForWorkspace", workspaceID, chatStatus, limit, offset)}
 }
 
-func (_c *Database_GetChatsForWorkspace_Call) Run(run func(workspaceID string, chatStatus string)) *Database_GetChatsForWorkspace_Call {
+func (_c *Database_GetChatsForWorkspace_Call) Run(run func(workspaceID string, chatStatus string, limit int, offset int)) *Database_GetChatsForWorkspace_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(string), args[1].(string), args[2].(int), args[3].(int))
 	})
 	return _c
 }
 
-func (_c *Database_GetChatsForWorkspace_Call) Return(_a0 []db.Chat, _a1 error) *Database_GetChatsForWorkspace_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *Database_GetChatsForWorkspace_Call) Return(_a0 []db.Chat, _a1 int64, _a2 error) *Database_GetChatsForWorkspace_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *Database_GetChatsForWorkspace_Call) RunAndReturn(run func(string, string) ([]db.Chat, error)) *Database_GetChatsForWorkspace_Call {
+func (_c *Database_GetChatsForWorkspace_Call) RunAndReturn(run func(string, string, int, int) ([]db.Chat, int64, error)) *Database_GetChatsForWorkspace_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Describe the Changes:
- Implemented pagination for chat history retrieval with `limit/offset` parameters while maintaining backward compatibility and added comprehensive unit tests.

Daily Bounty: https://community.sphinx.chat/bounty/4174?unlock=845238

### `Evidence Loom`:

https://github.com/user-attachments/assets/3431213b-fd0a-47be-82f7-e15e35f49042

### `Unit Test`:

![image](https://github.com/user-attachments/assets/f1d93adc-f0f6-47ee-8e0a-81e5f689747a)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and loom of changes in my PR