### PR TITLE
Add authenticated myAssigned bounty filter

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -804,20 +804,20 @@ func (db database) GetAssignedBounties(r *http.Request) ([]NewBounty, error) {
 
 	ms := []NewBounty{}
 
-    ctx := r.Context()
-    authenticatedPubKey, _ := ctx.Value(auth.ContextKey).(string)
-    isAuthenticated := authenticatedPubKey != "" && authenticatedPubKey == pubkey
+	ctx := r.Context()
+	authenticatedPubKey, _ := ctx.Value(auth.ContextKey).(string)
+	isAuthenticated := authenticatedPubKey != "" && authenticatedPubKey == pubkey
 
-    query := `SELECT * FROM public.bounty WHERE assignee = '` + pubkey + `'`
-    if isAuthenticated {
-        query += ` AND (show = true OR show = false)`
-    } else {
-        query += ` AND show = true`
-    }
+	query := `SELECT * FROM public.bounty WHERE assignee = '` + pubkey + `'`
+	if isAuthenticated {
+		query += ` AND (show = true OR show = false)`
+	} else {
+		query += ` AND show = true`
+	}
 
-    allQuery := query + " " + statusQuery + " " + orderQuery + " " + limitQuery
-    err := db.db.Raw(allQuery).Find(&ms).Error
-    return ms, err
+	allQuery := query + " " + statusQuery + " " + orderQuery + " " + limitQuery
+	err := db.db.Raw(allQuery).Find(&ms).Error
+	return ms, err
 }
 
 func (db database) GetCreatedBounties(r *http.Request) ([]NewBounty, error) {
@@ -2235,45 +2235,45 @@ func (db database) CreateBountyStake(stake BountyStake) (*BountyStake, error) {
 	if stake.BountyID == 0 {
 		return nil, errors.New("bounty ID is required")
 	}
-	
+
 	if stake.HunterPubKey == "" {
 		return nil, errors.New("hunter public key is required")
 	}
-	
+
 	if stake.Amount <= 0 {
 		return nil, errors.New("stake amount must be greater than zero")
 	}
-	
+
 	bounty := db.GetBounty(stake.BountyID)
 	if bounty.ID == 0 {
 		return nil, errors.New("bounty not found")
 	}
-	
+
 	if !bounty.IsStakable {
 		return nil, errors.New("bounty is not stakable")
 	}
-	
+
 	if stake.Amount < bounty.StakeMin {
 		return nil, fmt.Errorf("stake amount must be at least %d", bounty.StakeMin)
 	}
-	
+
 	if bounty.CurrentStakers >= bounty.MaxStakers {
 		return nil, errors.New("maximum number of stakers reached for this bounty")
 	}
-	
+
 	if stake.Status == "" {
 		stake.Status = StakeStatusNew
 	}
-	
+
 	if err := db.db.Create(&stake).Error; err != nil {
 		return nil, fmt.Errorf("failed to create bounty stake: %w", err)
 	}
-	
+
 	if err := db.db.Model(&NewBounty{}).Where("id = ?", stake.BountyID).
 		Update("current_stakers", gorm.Expr("current_stakers + 1")).Error; err != nil {
 		return nil, fmt.Errorf("failed to update bounty stakers count: %w", err)
 	}
-	
+
 	return &stake, nil
 }
 
@@ -2318,7 +2318,7 @@ func (db database) UpdateBountyStake(stakeID uuid.UUID, updates map[string]inter
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if statusVal, ok := updates["status"]; ok {
 		status, ok := statusVal.(StakeStatus)
 		if !ok {
@@ -2329,27 +2329,27 @@ func (db database) UpdateBountyStake(stakeID uuid.UUID, updates map[string]inter
 				return nil, errors.New("invalid status type")
 			}
 		}
-		
+
 		if status == StakeStatusActive && stake.StakedAt == nil {
 			now := time.Now()
 			updates["staked_at"] = now
 		}
-		
+
 		if status == StakeStatusReturned && stake.ReturnedAt == nil {
 			now := time.Now()
 			updates["returned_at"] = now
-			
+
 			if err := db.db.Model(&NewBounty{}).Where("id = ?", stake.BountyID).
 				Update("current_stakers", gorm.Expr("current_stakers - 1")).Error; err != nil {
 				return nil, fmt.Errorf("failed to update bounty stakers count: %w", err)
 			}
 		}
 	}
-	
+
 	if err := db.db.Model(&BountyStake{}).Where("id = ?", stakeID).Updates(updates).Error; err != nil {
 		return nil, fmt.Errorf("failed to update stake with ID %s: %w", stakeID, err)
 	}
-	
+
 	return db.GetBountyStakeByID(stakeID)
 }
 
@@ -2359,17 +2359,17 @@ func (db database) DeleteBountyStake(stakeID uuid.UUID) error {
 	if err != nil {
 		return err
 	}
-	
+
 	tx := db.db.Begin()
 	if tx.Error != nil {
 		return fmt.Errorf("failed to begin transaction: %w", tx.Error)
 	}
-	
+
 	if err := tx.Delete(&BountyStake{}, "id = ?", stakeID).Error; err != nil {
 		tx.Rollback()
 		return fmt.Errorf("failed to delete stake with ID %s: %w", stakeID, err)
 	}
-	
+
 	if stake.StakedAt != nil && stake.ReturnedAt == nil {
 		if err := tx.Model(&NewBounty{}).Where("id = ?", stake.BountyID).
 			Update("current_stakers", gorm.Expr("current_stakers - 1")).Error; err != nil {
@@ -2377,11 +2377,11 @@ func (db database) DeleteBountyStake(stakeID uuid.UUID) error {
 			return fmt.Errorf("failed to update bounty stakers count: %w", err)
 		}
 	}
-	
+
 	if err := tx.Commit().Error; err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -2389,44 +2389,44 @@ func (db database) CreateBountyStakeProcess(process *BountyStakeProcess) (*Bount
 	if process.BountyID == 0 {
 		return nil, errors.New("bounty ID is required")
 	}
-	
+
 	if process.HunterPubKey == "" {
 		return nil, errors.New("hunter public key is required")
 	}
-	
+
 	if process.Amount <= 0 {
 		return nil, errors.New("stake amount must be greater than zero")
 	}
-	
+
 	bounty := db.GetBounty(process.BountyID)
 	if bounty.ID == 0 {
 		return nil, errors.New("bounty not found")
 	}
-	
+
 	if !bounty.IsStakable {
 		return nil, errors.New("bounty is not stakable")
 	}
-	
+
 	if process.Amount < bounty.StakeMin {
 		return nil, fmt.Errorf("stake amount must be at least %d", bounty.StakeMin)
 	}
-	
+
 	if process.Status == "" {
 		process.Status = StakeProcessStatusNew
 	}
-	
+
 	if process.ID == uuid.Nil {
 		process.ID = uuid.New()
 	}
-	
+
 	now := time.Now()
 	process.CreatedAt = now
 	process.UpdatedAt = now
-	
+
 	if err := db.db.Create(process).Error; err != nil {
 		return nil, fmt.Errorf("failed to create stake process: %w", err)
 	}
-	
+
 	return process, nil
 }
 
@@ -2470,7 +2470,7 @@ func (db database) UpdateBountyStakeProcess(id uuid.UUID, updates map[string]int
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if statusVal, ok := updates["status"]; ok {
 		status, ok := statusVal.(StakeProcessStatus)
 		if !ok {
@@ -2481,23 +2481,23 @@ func (db database) UpdateBountyStakeProcess(id uuid.UUID, updates map[string]int
 				return nil, errors.New("invalid status type")
 			}
 		}
-		
+
 		now := time.Now()
 		updates["updated_at"] = now
-		
+
 		if status == StakeProcessStatusPaid && process.StakedAt == nil {
 			updates["staked_at"] = now
 		}
-		
+
 		if status == StakeProcessStatusReturned && process.ReturnedAt == nil {
 			updates["returned_at"] = now
 		}
 	}
-	
+
 	if err := db.db.Model(&BountyStakeProcess{}).Where("id = ?", id).Updates(updates).Error; err != nil {
 		return nil, fmt.Errorf("failed to update stake process with ID %s: %w", id, err)
 	}
-	
+
 	return db.GetBountyStakeProcessByID(id)
 }
 
@@ -2505,10 +2505,10 @@ func (db database) DeleteBountyStakeProcess(id uuid.UUID) error {
 	if _, err := db.GetBountyStakeProcessByID(id); err != nil {
 		return err
 	}
-	
+
 	if err := db.db.Delete(&BountyStakeProcess{}, "id = ?", id).Error; err != nil {
 		return fmt.Errorf("failed to delete stake process with ID %s: %w", id, err)
 	}
-	
+
 	return nil
 }

--- a/db/db.go
+++ b/db/db.go
@@ -1209,6 +1209,7 @@ func (db database) GetAllBounties(r *http.Request) []NewBounty {
 	paid := keys.Get("Paid")
 	pending := keys.Get("Pending")
 	failed := keys.Get("Failed")
+	myAssigned := keys.Get("myAssigned")
 	orgUuid := keys.Get("org_uuid")
 	workspaceUuid := keys.Get("workspace_uuid")
 	languages := keys.Get("languages")
@@ -1232,6 +1233,7 @@ func (db database) GetAllBounties(r *http.Request) []NewBounty {
 	phaseUuidQuery := ""
 	phasePriorityQuery := ""
 	accessRestrictionQuery := ""
+	myAssignedQuery := ""
 
 	if sortBy != "" && direction != "" {
 		orderQuery = "ORDER BY " + sortBy + " " + direction
@@ -1252,9 +1254,18 @@ func (db database) GetAllBounties(r *http.Request) []NewBounty {
 	if PhasePriority != "" {
 		phasePriorityQuery = "AND phase_priority = '" + PhasePriority + "'"
 	}
-	
+
 	if accessRestriction != "" {
 		accessRestrictionQuery = fmt.Sprintf("AND access_restriction = '%s'", accessRestriction)
+	}
+
+	if myAssigned == "true" {
+		if pubKey, ok := r.Context().Value(auth.ContextKey).(string); ok && pubKey != "" {
+			myAssignedQuery = fmt.Sprintf(
+				"AND assignee = '%s'",
+				strings.ReplaceAll(pubKey, "'", "''"),
+			)
+		}
 	}
 
 	var statusConditions []string
@@ -1304,7 +1315,7 @@ func (db database) GetAllBounties(r *http.Request) []NewBounty {
 
 	query := "SELECT * FROM public.bounty WHERE show != false"
 
-	allQuery := query + " " + statusQuery + " " + searchQuery + " " + workspaceQuery + " " + languageQuery + " " + phaseUuidQuery + " " + phasePriorityQuery + " " + accessRestrictionQuery + " " + orderQuery + " " + limitQuery
+	allQuery := query + " " + statusQuery + " " + searchQuery + " " + workspaceQuery + " " + languageQuery + " " + phaseUuidQuery + " " + phasePriorityQuery + " " + accessRestrictionQuery + " " + myAssignedQuery + " " + orderQuery + " " + limitQuery
 
 	theQuery := db.db.Raw(allQuery)
 

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -11,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -84,11 +87,62 @@ func handleTimingError(w http.ResponseWriter, operation string, err error) {
 //	@Success		200	{array}	db.Bounty
 //	@Router			/gobounties/all [get]
 func (h *bountyHandler) GetAllBounties(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("myAssigned") == "true" {
+		pubKey, err := getAuthenticatedPubKey(r)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		r = r.WithContext(context.WithValue(r.Context(), auth.ContextKey, pubKey))
+	}
+
 	bounties := h.db.GetAllBounties(r)
 	var bountyResponse []db.BountyResponse = h.GenerateBountyResponse(bounties)
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(bountyResponse)
+}
+
+func getAuthenticatedPubKey(r *http.Request) (string, error) {
+	if pubKey, ok := r.Context().Value(auth.ContextKey).(string); ok &&
+		pubKey != "" &&
+		pubKey != config.SWAuth {
+		return pubKey, nil
+	}
+
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		token = r.Header.Get("x-jwt")
+	}
+	if token == "" {
+		return "", errors.New("missing auth token")
+	}
+
+	isJwt := strings.Contains(token, ".") && !strings.HasPrefix(token, ".")
+	if isJwt {
+		claims, err := auth.DecodeJwt(token)
+		if err != nil {
+			return "", err
+		}
+		if !claims.VerifyExpiresAt(time.Now().Unix(), true) {
+			return "", errors.New("token has expired")
+		}
+		pubKey, ok := claims["pubkey"].(string)
+		if !ok || pubKey == "" {
+			return "", errors.New("missing pubkey claim")
+		}
+		return pubKey, nil
+	}
+
+	pubKey, err := auth.VerifyTribeUUID(token, true)
+	if err != nil || pubKey == "" {
+		if err != nil {
+			return "", err
+		}
+		return "", errors.New("missing pubkey")
+	}
+
+	return pubKey, nil
 }
 
 // GetBountyById godoc

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -2857,14 +2857,14 @@ func (h *bountyHandler) GetBountiesByWorkspaceTime(w http.ResponseWriter, r *htt
 func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	var stake db.BountyStake
 	if err := json.NewDecoder(r.Body).Decode(&stake); err != nil {
 		logger.Log.Error("[bounty_stake] invalid request body: %v", err)
@@ -2872,9 +2872,9 @@ func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	stake.HunterPubKey = pubKeyFromAuth
-	
+
 	createdStake, err := h.db.CreateBountyStake(stake)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to create stake: %v", err)
@@ -2882,7 +2882,7 @@ func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(createdStake)
 }
@@ -2904,7 +2904,7 @@ func (h *bountyHandler) GetAllBountyStakes(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -2929,7 +2929,7 @@ func (h *bountyHandler) GetBountyStakesByBountyID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid bounty ID"})
 		return
 	}
-	
+
 	stakes, err := h.db.GetBountyStakesByBountyID(bountyID)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stakes by bounty ID: %v", err)
@@ -2937,7 +2937,7 @@ func (h *bountyHandler) GetBountyStakesByBountyID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -2963,7 +2963,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	stake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stake by ID: %v", err)
@@ -2971,7 +2971,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stake)
 }
@@ -2988,7 +2988,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 //	@Router			/gobounties/stake/hunter/{hunterPubKey} [get]
 func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *http.Request) {
 	hunterPubKey := chi.URLParam(r, "hunterPubKey")
-	
+
 	stakes, err := h.db.GetBountyStakesByHunterPubKey(hunterPubKey)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stakes by hunter pubkey: %v", err)
@@ -2996,7 +2996,7 @@ func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -3020,14 +3020,14 @@ func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *
 func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3036,7 +3036,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	existingStake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] stake not found: %v", err)
@@ -3044,7 +3044,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingStake.BountyID)
 	if existingStake.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake] unauthorized update attempt")
@@ -3052,7 +3052,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to update this stake"})
 		return
 	}
-	
+
 	var updates map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
 		logger.Log.Error("[bounty_stake] invalid request body: %v", err)
@@ -3060,7 +3060,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	updatedStake, err := h.db.UpdateBountyStake(id, updates)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to update stake: %v", err)
@@ -3068,7 +3068,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(updatedStake)
 }
@@ -3090,14 +3090,14 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3106,7 +3106,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	existingStake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] stake not found: %v", err)
@@ -3114,7 +3114,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingStake.BountyID)
 	if existingStake.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake] unauthorized delete attempt")
@@ -3122,7 +3122,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to delete this stake"})
 		return
 	}
-	
+
 	err = h.db.DeleteBountyStake(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to delete stake: %v", err)
@@ -3130,7 +3130,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"message": "Stake deleted successfully"})
 }
@@ -3152,14 +3152,14 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	var process db.BountyStakeProcess
 	if err := json.NewDecoder(r.Body).Decode(&process); err != nil {
 		logger.Log.Error("[bounty_stake_process] invalid request body: %v", err)
@@ -3167,11 +3167,11 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	process.HunterPubKey = pubKeyFromAuth
-	
+
 	process.Status = db.StakeProcessStatusNew
-	
+
 	createdProcess, err := h.db.CreateBountyStakeProcess(&process)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to create stake process: %v", err)
@@ -3179,7 +3179,7 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(createdProcess)
 }
@@ -3198,14 +3198,14 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	processes, err := h.db.GetAllBountyStakeProcesses()
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to get stake processes: %v", err)
@@ -3213,7 +3213,7 @@ func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *htt
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stake processes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(processes)
 }
@@ -3235,14 +3235,14 @@ func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *htt
 func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3251,7 +3251,7 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	process, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to get process by ID: %v", err)
@@ -3259,7 +3259,7 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(process)
 }
@@ -3283,14 +3283,14 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3299,7 +3299,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	existingProcess, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] process not found: %v", err)
@@ -3307,7 +3307,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingProcess.BountyID)
 	if existingProcess.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake_process] unauthorized update attempt")
@@ -3315,7 +3315,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to update this stake process"})
 		return
 	}
-	
+
 	var updates map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
 		logger.Log.Error("[bounty_stake_process] invalid request body: %v", err)
@@ -3323,7 +3323,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	updatedProcess, err := h.db.UpdateBountyStakeProcess(id, updates)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to update process: %v", err)
@@ -3331,7 +3331,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(updatedProcess)
 }
@@ -3353,14 +3353,14 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3369,7 +3369,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	existingProcess, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] process not found: %v", err)
@@ -3377,7 +3377,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingProcess.BountyID)
 	if existingProcess.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake_process] unauthorized delete attempt")
@@ -3385,7 +3385,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to delete this stake process"})
 		return
 	}
-	
+
 	err = h.db.DeleteBountyStakeProcess(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to delete process: %v", err)
@@ -3393,7 +3393,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"message": "Stake process deleted successfully"})
 }

--- a/handlers/bounty_test.go
+++ b/handlers/bounty_test.go
@@ -1248,6 +1248,97 @@ func TestGetAllBounties(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.NotEmpty(t, returnedBounty)
 	})
+
+	t.Run("Should return only bounties assigned to authenticated user", func(t *testing.T) {
+		db.TestDB.DeleteAllBounties()
+		config.JwtKey = "test-jwt-key"
+		auth.InitJwt()
+
+		now := time.Now().Unix()
+		otherAssignee := db.Person{
+			Uuid:        "other_user_uuid",
+			OwnerAlias:  "other-user",
+			UniqueName:  "other-user",
+			OwnerPubKey: "other_user_pubkey",
+		}
+
+		db.TestDB.CreateOrEditPerson(bountyOwner)
+		db.TestDB.CreateOrEditPerson(bountyAssignee)
+		db.TestDB.CreateOrEditPerson(otherAssignee)
+
+		assignedToMe := db.NewBounty{
+			Type:        "coding",
+			Title:       "Assigned to me",
+			Description: "Assigned bounty description",
+			Assignee:    bountyAssignee.OwnerPubKey,
+			OwnerID:     bountyOwner.OwnerPubKey,
+			Show:        true,
+			Created:     now,
+		}
+		assignedToOther := db.NewBounty{
+			Type:        "coding",
+			Title:       "Assigned to other",
+			Description: "Other assigned bounty description",
+			Assignee:    otherAssignee.OwnerPubKey,
+			OwnerID:     bountyOwner.OwnerPubKey,
+			Show:        true,
+			Created:     now + 1,
+		}
+		openBounty := db.NewBounty{
+			Type:        "coding",
+			Title:       "Open bounty",
+			Description: "Open bounty description",
+			Assignee:    "",
+			OwnerID:     bountyOwner.OwnerPubKey,
+			Show:        true,
+			Created:     now + 2,
+		}
+		db.TestDB.CreateOrEditBounty(assignedToMe)
+		db.TestDB.CreateOrEditBounty(assignedToOther)
+		db.TestDB.CreateOrEditBounty(openBounty)
+
+		token, err := auth.EncodeJwt(bountyAssignee.OwnerPubKey)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetAllBounties)
+
+		rctx := chi.NewRouteContext()
+		req, _ := http.NewRequestWithContext(
+			context.WithValue(context.Background(), chi.RouteCtxKey, rctx),
+			http.MethodGet,
+			"/all?myAssigned=true&sortBy=created&direction=asc",
+			nil,
+		)
+		req.Header.Set("x-jwt", token)
+
+		handler.ServeHTTP(rr, req)
+
+		var returnedBounty []db.BountyResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &returnedBounty)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Len(t, returnedBounty, 1)
+		assert.Equal(t, assignedToMe.Title, returnedBounty[0].Bounty.Title)
+		assert.Equal(t, bountyAssignee.OwnerPubKey, returnedBounty[0].Bounty.Assignee)
+	})
+
+	t.Run("Should require authentication for my assigned filter", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(bHandler.GetAllBounties)
+
+		rctx := chi.NewRouteContext()
+		req, _ := http.NewRequestWithContext(
+			context.WithValue(context.Background(), chi.RouteCtxKey, rctx),
+			http.MethodGet,
+			"/all?myAssigned=true",
+			nil,
+		)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
 }
 
 func MockNewWSServer(t *testing.T) (*httptest.Server, *websocket.Conn) {

--- a/handlers/bounty_test.go
+++ b/handlers/bounty_test.go
@@ -1165,7 +1165,7 @@ func TestGetBountyIndexById(t *testing.T) {
 			OwnerID:       bountyOwner.OwnerPubKey,
 			Show:          true,
 			Created:       now,
-			MaxStakers: 1,
+			MaxStakers:    1,
 		}
 
 		db.TestDB.CreateOrEditBounty(bounty)

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -5696,6 +5696,62 @@ func (_c *Database_GetBountyByCreated_Call) RunAndReturn(run func(uint) (db.NewB
 	return _c
 }
 
+// GetBountyByUnlockCode provides a mock function with given fields: code
+func (_m *Database) GetBountyByUnlockCode(code string) (db.NewBounty, error) {
+	ret := _m.Called(code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBountyByUnlockCode")
+	}
+
+	var r0 db.NewBounty
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (db.NewBounty, error)); ok {
+		return rf(code)
+	}
+	if rf, ok := ret.Get(0).(func(string) db.NewBounty); ok {
+		r0 = rf(code)
+	} else {
+		r0 = ret.Get(0).(db.NewBounty)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(code)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Database_GetBountyByUnlockCode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBountyByUnlockCode'
+type Database_GetBountyByUnlockCode_Call struct {
+	*mock.Call
+}
+
+// GetBountyByUnlockCode is a helper method to define mock.On call
+//   - code string
+func (_e *Database_Expecter) GetBountyByUnlockCode(code interface{}) *Database_GetBountyByUnlockCode_Call {
+	return &Database_GetBountyByUnlockCode_Call{Call: _e.mock.On("GetBountyByUnlockCode", code)}
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) Run(run func(code string)) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) Return(_a0 db.NewBounty, _a1 error) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) RunAndReturn(run func(string) (db.NewBounty, error)) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBountyById provides a mock function with given fields: id
 func (_m *Database) GetBountyById(id string) ([]db.NewBounty, error) {
 	ret := _m.Called(id)
@@ -17486,7 +17542,6 @@ func (_c *Database_GetAllBountyStakes_Call) RunAndReturn(run func() ([]db.Bounty
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakesByBountyID(bountyID uint) ([]db.BountyStake, error) {
 	ret := _m.Called(bountyID)
 
@@ -17703,7 +17758,6 @@ func (_c *Database_UpdateBountyStake_Call) RunAndReturn(run func(uuid.UUID, map[
 	return _c
 }
 
-
 func (_m *Database) DeleteBountyStake(stakeID uuid.UUID) error {
 	ret := _m.Called(stakeID)
 
@@ -17746,7 +17800,6 @@ func (_c *Database_DeleteBountyStake_Call) RunAndReturn(run func(uuid.UUID) erro
 	return _c
 }
 
-
 func (_m *Database) AddChatStatus(status *db.ChatWorkflowStatus) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(status)
 
@@ -17778,7 +17831,6 @@ type Database_AddChatStatus_Call struct {
 	*mock.Call
 }
 
-
 func (_e *Database_Expecter) AddChatStatus(status interface{}) *Database_AddChatStatus_Call {
 	return &Database_AddChatStatus_Call{Call: _e.mock.On("AddChatStatus", status)}
 }
@@ -17799,7 +17851,6 @@ func (_c *Database_AddChatStatus_Call) RunAndReturn(run func(*db.ChatWorkflowSta
 	_c.Call.Return(run)
 	return _c
 }
-
 
 func (_m *Database) UpdateChatStatus(status *db.ChatWorkflowStatus) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(status)
@@ -17831,7 +17882,6 @@ func (_m *Database) UpdateChatStatus(status *db.ChatWorkflowStatus) (db.ChatWork
 type Database_UpdateChatStatus_Call struct {
 	*mock.Call
 }
-
 
 func (_e *Database_Expecter) UpdateChatStatus(status interface{}) *Database_UpdateChatStatus_Call {
 	return &Database_UpdateChatStatus_Call{Call: _e.mock.On("UpdateChatStatus", status)}
@@ -17908,7 +17958,6 @@ func (_c *Database_GetChatStatusByChatID_Call) RunAndReturn(run func(string) ([]
 	return _c
 }
 
-
 func (_m *Database) GetLatestChatStatusByChatID(chatID string) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(chatID)
 
@@ -17981,7 +18030,6 @@ func (_m *Database) DeleteChatStatus(_a0 uuid.UUID) error {
 type Database_DeleteChatStatus_Call struct {
 	*mock.Call
 }
-
 
 func (_e *Database_Expecter) DeleteChatStatus(_a0 interface{}) *Database_DeleteChatStatus_Call {
 	return &Database_DeleteChatStatus_Call{Call: _e.mock.On("DeleteChatStatus", _a0)}
@@ -18110,7 +18158,6 @@ func (_c *Database_CreateBountyStakeProcess_Call) RunAndReturn(run func(*db.Boun
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakeProcessByID(id uuid.UUID) (*db.BountyStakeProcess, error) {
 	ret := _m.Called(id)
 
@@ -18219,7 +18266,6 @@ func (_c *Database_GetBountyStakeProcessesByBountyID_Call) RunAndReturn(run func
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakeProcessesByHunterPubKey(hunterPubKey string) ([]db.BountyStakeProcess, error) {
 	ret := _m.Called(hunterPubKey)
 
@@ -18327,7 +18373,6 @@ func (_c *Database_GetAllBountyStakeProcesses_Call) RunAndReturn(run func() ([]d
 	_c.Call.Return(run)
 	return _c
 }
-
 
 func (_m *Database) UpdateBountyStakeProcess(id uuid.UUID, updates map[string]interface{}) (*db.BountyStakeProcess, error) {
 	ret := _m.Called(id, updates)


### PR DESCRIPTION
## Summary
- require authentication when `/gobounties/all?myAssigned=true` is requested
- filter the existing bounty query by the authenticated user pubkey while preserving existing status/search/language/pagination filters
- add handler coverage for the assigned-to-me result and unauthenticated request path

Closes #2436
Bounty: https://community.sphinx.chat/bounty/3334

## Companion PR

- Frontend support: stakwork/sphinx-tribes-frontend#1581

## Testing
- `go test ./handlers -run 'TestGetAllBounties' -count=1`
- `go test ./db -run '^$' -count=1`
- `gofmt -w db/db.go handlers/bounty.go handlers/bounty_test.go mocks/Database.go`
- `git diff --exit-code -- db/db.go handlers/bounty.go handlers/bounty_test.go mocks/Database.go`
- `git diff --check -- db/db.go handlers/bounty.go handlers/bounty_test.go mocks/Database.go`