### PR TITLE
Fix bounty payment retry status flow

### DIFF
--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -1426,33 +1426,11 @@ func (h *bountyHandler) UpdateBountyPaymentStatus(w http.ResponseWriter, r *http
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(msg)
 			return
-		} else if tagResult.Status == db.PaymentFailed {
-
-			err = h.db.ProcessReversePayments(payment.ID)
-
-			if err != nil {
-				log.Printf("Could not reverse bounty payment : Bounty ID - %d, Payment ID - %d, Error - %s", bounty.ID, payment.ID, err)
-			}
-
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(msg)
-			return
-		} else if tagResult.Status == db.PaymentPending {
-			if payment.PaymentStatus == db.PaymentPending {
-				created := utils.ConvertTimeToTimestamp(payment.Created.String())
-
-				now := time.Now()
-				daysDiff := utils.GetDateDaysDifference(int64(created), &now)
-
-				if daysDiff >= 7 {
-
-					err = h.db.ProcessReversePayments(payment.ID)
-					if err != nil {
-						log.Printf("Could not reverse bounty payment after 7 days : Bounty ID - %d, Payment ID - %d, Error - %s", bounty.ID, payment.ID, err)
-					}
-				}
-			}
 		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(msg)
+		return
 	}
 
 	msg := map[string]string{
@@ -2803,14 +2781,14 @@ func (h *bountyHandler) GetBountiesByWorkspaceTime(w http.ResponseWriter, r *htt
 func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	var stake db.BountyStake
 	if err := json.NewDecoder(r.Body).Decode(&stake); err != nil {
 		logger.Log.Error("[bounty_stake] invalid request body: %v", err)
@@ -2818,9 +2796,9 @@ func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	stake.HunterPubKey = pubKeyFromAuth
-	
+
 	createdStake, err := h.db.CreateBountyStake(stake)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to create stake: %v", err)
@@ -2828,7 +2806,7 @@ func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(createdStake)
 }
@@ -2850,7 +2828,7 @@ func (h *bountyHandler) GetAllBountyStakes(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -2875,7 +2853,7 @@ func (h *bountyHandler) GetBountyStakesByBountyID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid bounty ID"})
 		return
 	}
-	
+
 	stakes, err := h.db.GetBountyStakesByBountyID(bountyID)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stakes by bounty ID: %v", err)
@@ -2883,7 +2861,7 @@ func (h *bountyHandler) GetBountyStakesByBountyID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -2909,7 +2887,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	stake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stake by ID: %v", err)
@@ -2917,7 +2895,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stake)
 }
@@ -2934,7 +2912,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 //	@Router			/gobounties/stake/hunter/{hunterPubKey} [get]
 func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *http.Request) {
 	hunterPubKey := chi.URLParam(r, "hunterPubKey")
-	
+
 	stakes, err := h.db.GetBountyStakesByHunterPubKey(hunterPubKey)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stakes by hunter pubkey: %v", err)
@@ -2942,7 +2920,7 @@ func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -2966,14 +2944,14 @@ func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *
 func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -2982,7 +2960,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	existingStake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] stake not found: %v", err)
@@ -2990,7 +2968,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingStake.BountyID)
 	if existingStake.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake] unauthorized update attempt")
@@ -2998,7 +2976,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to update this stake"})
 		return
 	}
-	
+
 	var updates map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
 		logger.Log.Error("[bounty_stake] invalid request body: %v", err)
@@ -3006,7 +2984,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	updatedStake, err := h.db.UpdateBountyStake(id, updates)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to update stake: %v", err)
@@ -3014,7 +2992,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(updatedStake)
 }
@@ -3036,14 +3014,14 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3052,7 +3030,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	existingStake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] stake not found: %v", err)
@@ -3060,7 +3038,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingStake.BountyID)
 	if existingStake.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake] unauthorized delete attempt")
@@ -3068,7 +3046,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to delete this stake"})
 		return
 	}
-	
+
 	err = h.db.DeleteBountyStake(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to delete stake: %v", err)
@@ -3076,7 +3054,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"message": "Stake deleted successfully"})
 }
@@ -3098,14 +3076,14 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	var process db.BountyStakeProcess
 	if err := json.NewDecoder(r.Body).Decode(&process); err != nil {
 		logger.Log.Error("[bounty_stake_process] invalid request body: %v", err)
@@ -3113,11 +3091,11 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	process.HunterPubKey = pubKeyFromAuth
-	
+
 	process.Status = db.StakeProcessStatusNew
-	
+
 	createdProcess, err := h.db.CreateBountyStakeProcess(&process)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to create stake process: %v", err)
@@ -3125,7 +3103,7 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(createdProcess)
 }
@@ -3144,14 +3122,14 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	processes, err := h.db.GetAllBountyStakeProcesses()
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to get stake processes: %v", err)
@@ -3159,7 +3137,7 @@ func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *htt
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stake processes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(processes)
 }
@@ -3181,14 +3159,14 @@ func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *htt
 func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3197,7 +3175,7 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	process, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to get process by ID: %v", err)
@@ -3205,7 +3183,7 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(process)
 }
@@ -3229,14 +3207,14 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3245,7 +3223,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	existingProcess, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] process not found: %v", err)
@@ -3253,7 +3231,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingProcess.BountyID)
 	if existingProcess.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake_process] unauthorized update attempt")
@@ -3261,7 +3239,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to update this stake process"})
 		return
 	}
-	
+
 	var updates map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
 		logger.Log.Error("[bounty_stake_process] invalid request body: %v", err)
@@ -3269,7 +3247,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	updatedProcess, err := h.db.UpdateBountyStakeProcess(id, updates)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to update process: %v", err)
@@ -3277,7 +3255,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(updatedProcess)
 }
@@ -3299,14 +3277,14 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3315,7 +3293,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	existingProcess, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] process not found: %v", err)
@@ -3323,7 +3301,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingProcess.BountyID)
 	if existingProcess.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake_process] unauthorized delete attempt")
@@ -3331,7 +3309,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to delete this stake process"})
 		return
 	}
-	
+
 	err = h.db.DeleteBountyStakeProcess(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to delete process: %v", err)
@@ -3339,7 +3317,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"message": "Stake process deleted successfully"})
 }

--- a/handlers/bounty_test.go
+++ b/handlers/bounty_test.go
@@ -1165,7 +1165,7 @@ func TestGetBountyIndexById(t *testing.T) {
 			OwnerID:       bountyOwner.OwnerPubKey,
 			Show:          true,
 			Created:       now,
-			MaxStakers: 1,
+			MaxStakers:    1,
 		}
 
 		db.TestDB.CreateOrEditBounty(bounty)
@@ -1612,6 +1612,13 @@ func TestUpdateBountyPaymentStatus(t *testing.T) {
 			Error:  "",
 		}
 	}
+	mockFailedGetInvoiceStatusByTag := func(tag string) db.V2TagRes {
+		return db.V2TagRes{
+			Status: db.PaymentFailed,
+			Tag:    paymentTag,
+			Error:  "payment failed",
+		}
+	}
 
 	now := time.Now().UnixMilli()
 	bountyOwnerId := "owner_pubkey"
@@ -1647,16 +1654,17 @@ func TestUpdateBountyPaymentStatus(t *testing.T) {
 
 	bountyAmount := uint(3000)
 	bounty := db.NewBounty{
-		OwnerID:       bountyOwnerId,
-		Price:         bountyAmount,
-		Created:       now,
-		Type:          "coding",
-		Title:         "updateBountyTitle",
-		Description:   "updateBountyDescription",
-		Assignee:      person.OwnerPubKey,
-		Show:          true,
-		WorkspaceUuid: workspace.Uuid,
-		Paid:          false,
+		OwnerID:        bountyOwnerId,
+		Price:          bountyAmount,
+		Created:        now,
+		Type:           "coding",
+		Title:          "updateBountyTitle",
+		Description:    "updateBountyDescription",
+		Assignee:       person.OwnerPubKey,
+		Show:           true,
+		WorkspaceUuid:  workspace.Uuid,
+		Paid:           false,
+		PaymentPending: true,
 	}
 	db.TestDB.CreateOrEditBounty(bounty)
 
@@ -1705,7 +1713,7 @@ func TestUpdateBountyPaymentStatus(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, rr.Code, "Expected 401 Unauthorized for unauthorized access")
 	})
 
-	t.Run("Should test that a PENDING payment_status is sent if the payment is not successful", func(t *testing.T) {
+	t.Run("Should test that a PENDING payment_status is sent without updating the bounty if the payment is not complete", func(t *testing.T) {
 		mockHttpClient := &mocks.HttpClient{}
 
 		bHandler := NewBountyHandler(mockHttpClient, db.TestDB)
@@ -1722,8 +1730,96 @@ func TestUpdateBountyPaymentStatus(t *testing.T) {
 		}
 
 		ro.ServeHTTP(rr, req)
-		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		res := map[string]string{}
+		err = json.Unmarshal(rr.Body.Bytes(), &res)
+		assert.NoError(t, err)
+		assert.Equal(t, db.PaymentPending, res["payment_status"])
+
+		updatedBounty := db.TestDB.GetBounty(bountyId)
+		assert.False(t, updatedBounty.Paid, "Expected pending status retry to leave bounty unpaid")
+		assert.True(t, updatedBounty.PaymentPending, "Expected pending status retry to leave bounty pending")
 		mockHttpClient.AssertExpectations(t)
+	})
+
+	t.Run("Should test that a FAILED payment_status is sent without reversing or updating the bounty", func(t *testing.T) {
+		mockHttpClient := &mocks.HttpClient{}
+
+		bHandler := NewBountyHandler(mockHttpClient, db.TestDB)
+		bHandler.getInvoiceStatusByTag = mockFailedGetInvoiceStatusByTag
+
+		failedRetryCreated := now + 1
+		failedRetryBounty := bounty
+		failedRetryBounty.Created = failedRetryCreated
+		failedRetryBounty.PaymentPending = true
+		failedRetryBounty.PaymentFailed = false
+		failedRetryBounty.Paid = false
+		db.TestDB.CreateOrEditBounty(failedRetryBounty)
+
+		dbFailedRetryBounty, err := db.TestDB.GetBountyDataByCreated(strconv.FormatInt(failedRetryCreated, 10))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		failedRetryBountyId := dbFailedRetryBounty[0].ID
+		failedRetryBountyIdStr := strconv.FormatInt(int64(failedRetryBountyId), 10)
+		failedRetryTag := "failed_update_tag"
+		failedRetryPaymentTime := time.Now()
+		workspaceBudgetBeforeFailedRetry := db.TestDB.GetWorkspaceBudget(workspace.Uuid)
+
+		depositHistory := db.NewPaymentHistory{
+			Amount:        budgetAmount,
+			WorkspaceUuid: workspace.Uuid,
+			PaymentType:   db.Deposit,
+			Status:        true,
+			Created:       &failedRetryPaymentTime,
+			Updated:       &failedRetryPaymentTime,
+		}
+		pendingPayment := db.NewPaymentHistory{
+			Amount:         bountyAmount,
+			BountyId:       failedRetryBountyId,
+			PaymentStatus:  db.PaymentPending,
+			WorkspaceUuid:  workspace.Uuid,
+			PaymentType:    db.Payment,
+			SenderPubKey:   person.OwnerPubKey,
+			ReceiverPubKey: person.OwnerPubKey,
+			Tag:            failedRetryTag,
+			Status:         true,
+			Created:        &failedRetryPaymentTime,
+			Updated:        &failedRetryPaymentTime,
+		}
+		db.TestDB.AddPaymentHistory(depositHistory)
+		db.TestDB.AddPaymentHistory(pendingPayment)
+
+		ro := chi.NewRouter()
+		ro.Put("/gobounties/payment/status/{id}", bHandler.UpdateBountyPaymentStatus)
+
+		rr := httptest.NewRecorder()
+		requestBody := bytes.NewBuffer([]byte("{}"))
+		req, err := http.NewRequestWithContext(authorizedCtx, http.MethodPut, "/gobounties/payment/status/"+failedRetryBountyIdStr, requestBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ro.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		res := map[string]string{}
+		err = json.Unmarshal(rr.Body.Bytes(), &res)
+		assert.NoError(t, err)
+		assert.Equal(t, db.PaymentFailed, res["payment_status"])
+
+		updatedBounty := db.TestDB.GetBounty(failedRetryBountyId)
+		assert.False(t, updatedBounty.Paid, "Expected failed status retry to leave bounty unpaid")
+		assert.True(t, updatedBounty.PaymentPending, "Expected failed status retry to leave bounty pending")
+		assert.False(t, updatedBounty.PaymentFailed, "Expected failed status retry not to mark the bounty failed")
+
+		updatedPayment := db.TestDB.GetPaymentByBountyId(failedRetryBountyId)
+		assert.Equal(t, db.PaymentPending, updatedPayment.PaymentStatus, "Expected failed status retry not to mutate the stored payment")
+
+		workspaceBudgetAfterFailedRetry := db.TestDB.GetWorkspaceBudget(workspace.Uuid)
+		assert.Equal(t, workspaceBudgetBeforeFailedRetry.TotalBudget, workspaceBudgetAfterFailedRetry.TotalBudget, "Expected failed status retry not to reverse budget")
 	})
 
 	t.Run("Should test that a COMPLETE payment_status is sent if the payment is successful", func(t *testing.T) {
@@ -1751,6 +1847,7 @@ func TestUpdateBountyPaymentStatus(t *testing.T) {
 
 		updatedBounty := db.TestDB.GetBounty(bountyId)
 		assert.True(t, updatedBounty.Paid, "Expected bounty to be marked as paid")
+		assert.False(t, updatedBounty.PaymentPending, "Expected completed payment retry to clear pending payment state")
 		assert.Equal(t, payment.PaymentStatus, db.PaymentComplete, "Expected Payment Status To be Complete")
 	})
 

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -5696,6 +5696,62 @@ func (_c *Database_GetBountyByCreated_Call) RunAndReturn(run func(uint) (db.NewB
 	return _c
 }
 
+// GetBountyByUnlockCode provides a mock function with given fields: code
+func (_m *Database) GetBountyByUnlockCode(code string) (db.NewBounty, error) {
+	ret := _m.Called(code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBountyByUnlockCode")
+	}
+
+	var r0 db.NewBounty
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (db.NewBounty, error)); ok {
+		return rf(code)
+	}
+	if rf, ok := ret.Get(0).(func(string) db.NewBounty); ok {
+		r0 = rf(code)
+	} else {
+		r0 = ret.Get(0).(db.NewBounty)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(code)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Database_GetBountyByUnlockCode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBountyByUnlockCode'
+type Database_GetBountyByUnlockCode_Call struct {
+	*mock.Call
+}
+
+// GetBountyByUnlockCode is a helper method to define mock.On call
+//   - code string
+func (_e *Database_Expecter) GetBountyByUnlockCode(code interface{}) *Database_GetBountyByUnlockCode_Call {
+	return &Database_GetBountyByUnlockCode_Call{Call: _e.mock.On("GetBountyByUnlockCode", code)}
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) Run(run func(code string)) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) Return(_a0 db.NewBounty, _a1 error) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) RunAndReturn(run func(string) (db.NewBounty, error)) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBountyById provides a mock function with given fields: id
 func (_m *Database) GetBountyById(id string) ([]db.NewBounty, error) {
 	ret := _m.Called(id)
@@ -17486,7 +17542,6 @@ func (_c *Database_GetAllBountyStakes_Call) RunAndReturn(run func() ([]db.Bounty
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakesByBountyID(bountyID uint) ([]db.BountyStake, error) {
 	ret := _m.Called(bountyID)
 
@@ -17703,7 +17758,6 @@ func (_c *Database_UpdateBountyStake_Call) RunAndReturn(run func(uuid.UUID, map[
 	return _c
 }
 
-
 func (_m *Database) DeleteBountyStake(stakeID uuid.UUID) error {
 	ret := _m.Called(stakeID)
 
@@ -17746,7 +17800,6 @@ func (_c *Database_DeleteBountyStake_Call) RunAndReturn(run func(uuid.UUID) erro
 	return _c
 }
 
-
 func (_m *Database) AddChatStatus(status *db.ChatWorkflowStatus) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(status)
 
@@ -17778,7 +17831,6 @@ type Database_AddChatStatus_Call struct {
 	*mock.Call
 }
 
-
 func (_e *Database_Expecter) AddChatStatus(status interface{}) *Database_AddChatStatus_Call {
 	return &Database_AddChatStatus_Call{Call: _e.mock.On("AddChatStatus", status)}
 }
@@ -17799,7 +17851,6 @@ func (_c *Database_AddChatStatus_Call) RunAndReturn(run func(*db.ChatWorkflowSta
 	_c.Call.Return(run)
 	return _c
 }
-
 
 func (_m *Database) UpdateChatStatus(status *db.ChatWorkflowStatus) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(status)
@@ -17831,7 +17882,6 @@ func (_m *Database) UpdateChatStatus(status *db.ChatWorkflowStatus) (db.ChatWork
 type Database_UpdateChatStatus_Call struct {
 	*mock.Call
 }
-
 
 func (_e *Database_Expecter) UpdateChatStatus(status interface{}) *Database_UpdateChatStatus_Call {
 	return &Database_UpdateChatStatus_Call{Call: _e.mock.On("UpdateChatStatus", status)}
@@ -17908,7 +17958,6 @@ func (_c *Database_GetChatStatusByChatID_Call) RunAndReturn(run func(string) ([]
 	return _c
 }
 
-
 func (_m *Database) GetLatestChatStatusByChatID(chatID string) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(chatID)
 
@@ -17981,7 +18030,6 @@ func (_m *Database) DeleteChatStatus(_a0 uuid.UUID) error {
 type Database_DeleteChatStatus_Call struct {
 	*mock.Call
 }
-
 
 func (_e *Database_Expecter) DeleteChatStatus(_a0 interface{}) *Database_DeleteChatStatus_Call {
 	return &Database_DeleteChatStatus_Call{Call: _e.mock.On("DeleteChatStatus", _a0)}
@@ -18110,7 +18158,6 @@ func (_c *Database_CreateBountyStakeProcess_Call) RunAndReturn(run func(*db.Boun
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakeProcessByID(id uuid.UUID) (*db.BountyStakeProcess, error) {
 	ret := _m.Called(id)
 
@@ -18219,7 +18266,6 @@ func (_c *Database_GetBountyStakeProcessesByBountyID_Call) RunAndReturn(run func
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakeProcessesByHunterPubKey(hunterPubKey string) ([]db.BountyStakeProcess, error) {
 	ret := _m.Called(hunterPubKey)
 
@@ -18327,7 +18373,6 @@ func (_c *Database_GetAllBountyStakeProcesses_Call) RunAndReturn(run func() ([]d
 	_c.Call.Return(run)
 	return _c
 }
-
 
 func (_m *Database) UpdateBountyStakeProcess(id uuid.UUID, updates map[string]interface{}) (*db.BountyStakeProcess, error) {
 	ret := _m.Called(id, updates)


### PR DESCRIPTION
Fixes #1901

## Summary
- keep `UpdateBountyPaymentStatus` read-only for non-`COMPLETE` retry results
- return the V2 bot status (`PENDING` or `FAILED`) instead of falling through to `NOTPAID`
- add payment retry coverage for pending, failed, and completed status handling
- add the missing generated `GetBountyByUnlockCode` database mock so handler tests compile against the current interface

## Validation
- `go test ./handlers -run '^$' -count=1`
- `git diff --check`

`go test ./handlers -run TestUpdateBountyPaymentStatus -count=1` is blocked locally because the Postgres test DB is not running at `localhost:5532`, and Docker Desktop's daemon is unavailable for `docker compose -f docker/testdb-docker-compose.yml -p test_db up -d`.