### PR TITLE
Add assigned-to-me bounty filter

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -804,20 +804,20 @@ func (db database) GetAssignedBounties(r *http.Request) ([]NewBounty, error) {
 
 	ms := []NewBounty{}
 
-    ctx := r.Context()
-    authenticatedPubKey, _ := ctx.Value(auth.ContextKey).(string)
-    isAuthenticated := authenticatedPubKey != "" && authenticatedPubKey == pubkey
+	ctx := r.Context()
+	authenticatedPubKey, _ := ctx.Value(auth.ContextKey).(string)
+	isAuthenticated := authenticatedPubKey != "" && authenticatedPubKey == pubkey
 
-    query := `SELECT * FROM public.bounty WHERE assignee = '` + pubkey + `'`
-    if isAuthenticated {
-        query += ` AND (show = true OR show = false)`
-    } else {
-        query += ` AND show = true`
-    }
+	query := `SELECT * FROM public.bounty WHERE assignee = '` + pubkey + `'`
+	if isAuthenticated {
+		query += ` AND (show = true OR show = false)`
+	} else {
+		query += ` AND show = true`
+	}
 
-    allQuery := query + " " + statusQuery + " " + orderQuery + " " + limitQuery
-    err := db.db.Raw(allQuery).Find(&ms).Error
-    return ms, err
+	allQuery := query + " " + statusQuery + " " + orderQuery + " " + limitQuery
+	err := db.db.Raw(allQuery).Find(&ms).Error
+	return ms, err
 }
 
 func (db database) GetCreatedBounties(r *http.Request) ([]NewBounty, error) {
@@ -1209,6 +1209,7 @@ func (db database) GetAllBounties(r *http.Request) []NewBounty {
 	paid := keys.Get("Paid")
 	pending := keys.Get("Pending")
 	failed := keys.Get("Failed")
+	myAssigned := keys.Get("myAssigned")
 	orgUuid := keys.Get("org_uuid")
 	workspaceUuid := keys.Get("workspace_uuid")
 	languages := keys.Get("languages")
@@ -1232,6 +1233,7 @@ func (db database) GetAllBounties(r *http.Request) []NewBounty {
 	phaseUuidQuery := ""
 	phasePriorityQuery := ""
 	accessRestrictionQuery := ""
+	myAssignedQuery := ""
 
 	if sortBy != "" && direction != "" {
 		orderQuery = "ORDER BY " + sortBy + " " + direction
@@ -1252,9 +1254,16 @@ func (db database) GetAllBounties(r *http.Request) []NewBounty {
 	if PhasePriority != "" {
 		phasePriorityQuery = "AND phase_priority = '" + PhasePriority + "'"
 	}
-	
+
 	if accessRestriction != "" {
 		accessRestrictionQuery = fmt.Sprintf("AND access_restriction = '%s'", accessRestriction)
+	}
+	if myAssigned == "true" {
+		pubKeyFromAuth, _ := r.Context().Value(auth.ContextKey).(string)
+		if pubKeyFromAuth == "" {
+			return ms
+		}
+		myAssignedQuery = fmt.Sprintf("AND assignee = '%s'", strings.ReplaceAll(pubKeyFromAuth, "'", "''"))
 	}
 
 	var statusConditions []string
@@ -1304,7 +1313,7 @@ func (db database) GetAllBounties(r *http.Request) []NewBounty {
 
 	query := "SELECT * FROM public.bounty WHERE show != false"
 
-	allQuery := query + " " + statusQuery + " " + searchQuery + " " + workspaceQuery + " " + languageQuery + " " + phaseUuidQuery + " " + phasePriorityQuery + " " + accessRestrictionQuery + " " + orderQuery + " " + limitQuery
+	allQuery := query + " " + statusQuery + " " + searchQuery + " " + workspaceQuery + " " + languageQuery + " " + phaseUuidQuery + " " + phasePriorityQuery + " " + accessRestrictionQuery + " " + myAssignedQuery + " " + orderQuery + " " + limitQuery
 
 	theQuery := db.db.Raw(allQuery)
 
@@ -2224,45 +2233,45 @@ func (db database) CreateBountyStake(stake BountyStake) (*BountyStake, error) {
 	if stake.BountyID == 0 {
 		return nil, errors.New("bounty ID is required")
 	}
-	
+
 	if stake.HunterPubKey == "" {
 		return nil, errors.New("hunter public key is required")
 	}
-	
+
 	if stake.Amount <= 0 {
 		return nil, errors.New("stake amount must be greater than zero")
 	}
-	
+
 	bounty := db.GetBounty(stake.BountyID)
 	if bounty.ID == 0 {
 		return nil, errors.New("bounty not found")
 	}
-	
+
 	if !bounty.IsStakable {
 		return nil, errors.New("bounty is not stakable")
 	}
-	
+
 	if stake.Amount < bounty.StakeMin {
 		return nil, fmt.Errorf("stake amount must be at least %d", bounty.StakeMin)
 	}
-	
+
 	if bounty.CurrentStakers >= bounty.MaxStakers {
 		return nil, errors.New("maximum number of stakers reached for this bounty")
 	}
-	
+
 	if stake.Status == "" {
 		stake.Status = StakeStatusNew
 	}
-	
+
 	if err := db.db.Create(&stake).Error; err != nil {
 		return nil, fmt.Errorf("failed to create bounty stake: %w", err)
 	}
-	
+
 	if err := db.db.Model(&NewBounty{}).Where("id = ?", stake.BountyID).
 		Update("current_stakers", gorm.Expr("current_stakers + 1")).Error; err != nil {
 		return nil, fmt.Errorf("failed to update bounty stakers count: %w", err)
 	}
-	
+
 	return &stake, nil
 }
 
@@ -2307,7 +2316,7 @@ func (db database) UpdateBountyStake(stakeID uuid.UUID, updates map[string]inter
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if statusVal, ok := updates["status"]; ok {
 		status, ok := statusVal.(StakeStatus)
 		if !ok {
@@ -2318,27 +2327,27 @@ func (db database) UpdateBountyStake(stakeID uuid.UUID, updates map[string]inter
 				return nil, errors.New("invalid status type")
 			}
 		}
-		
+
 		if status == StakeStatusActive && stake.StakedAt == nil {
 			now := time.Now()
 			updates["staked_at"] = now
 		}
-		
+
 		if status == StakeStatusReturned && stake.ReturnedAt == nil {
 			now := time.Now()
 			updates["returned_at"] = now
-			
+
 			if err := db.db.Model(&NewBounty{}).Where("id = ?", stake.BountyID).
 				Update("current_stakers", gorm.Expr("current_stakers - 1")).Error; err != nil {
 				return nil, fmt.Errorf("failed to update bounty stakers count: %w", err)
 			}
 		}
 	}
-	
+
 	if err := db.db.Model(&BountyStake{}).Where("id = ?", stakeID).Updates(updates).Error; err != nil {
 		return nil, fmt.Errorf("failed to update stake with ID %s: %w", stakeID, err)
 	}
-	
+
 	return db.GetBountyStakeByID(stakeID)
 }
 
@@ -2348,17 +2357,17 @@ func (db database) DeleteBountyStake(stakeID uuid.UUID) error {
 	if err != nil {
 		return err
 	}
-	
+
 	tx := db.db.Begin()
 	if tx.Error != nil {
 		return fmt.Errorf("failed to begin transaction: %w", tx.Error)
 	}
-	
+
 	if err := tx.Delete(&BountyStake{}, "id = ?", stakeID).Error; err != nil {
 		tx.Rollback()
 		return fmt.Errorf("failed to delete stake with ID %s: %w", stakeID, err)
 	}
-	
+
 	if stake.StakedAt != nil && stake.ReturnedAt == nil {
 		if err := tx.Model(&NewBounty{}).Where("id = ?", stake.BountyID).
 			Update("current_stakers", gorm.Expr("current_stakers - 1")).Error; err != nil {
@@ -2366,11 +2375,11 @@ func (db database) DeleteBountyStake(stakeID uuid.UUID) error {
 			return fmt.Errorf("failed to update bounty stakers count: %w", err)
 		}
 	}
-	
+
 	if err := tx.Commit().Error; err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -2378,44 +2387,44 @@ func (db database) CreateBountyStakeProcess(process *BountyStakeProcess) (*Bount
 	if process.BountyID == 0 {
 		return nil, errors.New("bounty ID is required")
 	}
-	
+
 	if process.HunterPubKey == "" {
 		return nil, errors.New("hunter public key is required")
 	}
-	
+
 	if process.Amount <= 0 {
 		return nil, errors.New("stake amount must be greater than zero")
 	}
-	
+
 	bounty := db.GetBounty(process.BountyID)
 	if bounty.ID == 0 {
 		return nil, errors.New("bounty not found")
 	}
-	
+
 	if !bounty.IsStakable {
 		return nil, errors.New("bounty is not stakable")
 	}
-	
+
 	if process.Amount < bounty.StakeMin {
 		return nil, fmt.Errorf("stake amount must be at least %d", bounty.StakeMin)
 	}
-	
+
 	if process.Status == "" {
 		process.Status = StakeProcessStatusNew
 	}
-	
+
 	if process.ID == uuid.Nil {
 		process.ID = uuid.New()
 	}
-	
+
 	now := time.Now()
 	process.CreatedAt = now
 	process.UpdatedAt = now
-	
+
 	if err := db.db.Create(process).Error; err != nil {
 		return nil, fmt.Errorf("failed to create stake process: %w", err)
 	}
-	
+
 	return process, nil
 }
 
@@ -2459,7 +2468,7 @@ func (db database) UpdateBountyStakeProcess(id uuid.UUID, updates map[string]int
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if statusVal, ok := updates["status"]; ok {
 		status, ok := statusVal.(StakeProcessStatus)
 		if !ok {
@@ -2470,23 +2479,23 @@ func (db database) UpdateBountyStakeProcess(id uuid.UUID, updates map[string]int
 				return nil, errors.New("invalid status type")
 			}
 		}
-		
+
 		now := time.Now()
 		updates["updated_at"] = now
-		
+
 		if status == StakeProcessStatusPaid && process.StakedAt == nil {
 			updates["staked_at"] = now
 		}
-		
+
 		if status == StakeProcessStatusReturned && process.ReturnedAt == nil {
 			updates["returned_at"] = now
 		}
 	}
-	
+
 	if err := db.db.Model(&BountyStakeProcess{}).Where("id = ?", id).Updates(updates).Error; err != nil {
 		return nil, fmt.Errorf("failed to update stake process with ID %s: %w", id, err)
 	}
-	
+
 	return db.GetBountyStakeProcessByID(id)
 }
 
@@ -2494,10 +2503,10 @@ func (db database) DeleteBountyStakeProcess(id uuid.UUID) error {
 	if _, err := db.GetBountyStakeProcessByID(id); err != nil {
 		return err
 	}
-	
+
 	if err := db.db.Delete(&BountyStakeProcess{}, "id = ?", id).Error; err != nil {
 		return fmt.Errorf("failed to delete stake process with ID %s: %w", id, err)
 	}
-	
+
 	return nil
 }

--- a/handlers/bounty.go
+++ b/handlers/bounty.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -84,11 +86,53 @@ func handleTimingError(w http.ResponseWriter, operation string, err error) {
 //	@Success		200	{array}	db.Bounty
 //	@Router			/gobounties/all [get]
 func (h *bountyHandler) GetAllBounties(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("myAssigned") == "true" {
+		pubKeyFromAuth := getPubKeyFromBountyRequest(r)
+		if pubKeyFromAuth == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode("Unauthorized")
+			return
+		}
+		r = r.WithContext(context.WithValue(r.Context(), auth.ContextKey, pubKeyFromAuth))
+	}
+
 	bounties := h.db.GetAllBounties(r)
 	var bountyResponse []db.BountyResponse = h.GenerateBountyResponse(bounties)
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(bountyResponse)
+}
+
+func getPubKeyFromBountyRequest(r *http.Request) string {
+	if pubKeyFromAuth, ok := r.Context().Value(auth.ContextKey).(string); ok {
+		return pubKeyFromAuth
+	}
+
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		token = r.Header.Get("x-jwt")
+	}
+	if token == "" {
+		return ""
+	}
+
+	isJwt := strings.Contains(token, ".") && !strings.HasPrefix(token, ".")
+	if isJwt {
+		claims, err := auth.DecodeJwt(token)
+		if err != nil {
+			return ""
+		}
+		if pubKey, ok := claims["pubkey"].(string); ok {
+			return pubKey
+		}
+		return ""
+	}
+
+	pubKey, err := auth.VerifyTribeUUID(token, true)
+	if err != nil {
+		return ""
+	}
+	return pubKey
 }
 
 // GetBountyById godoc
@@ -2803,14 +2847,14 @@ func (h *bountyHandler) GetBountiesByWorkspaceTime(w http.ResponseWriter, r *htt
 func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	var stake db.BountyStake
 	if err := json.NewDecoder(r.Body).Decode(&stake); err != nil {
 		logger.Log.Error("[bounty_stake] invalid request body: %v", err)
@@ -2818,9 +2862,9 @@ func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	stake.HunterPubKey = pubKeyFromAuth
-	
+
 	createdStake, err := h.db.CreateBountyStake(stake)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to create stake: %v", err)
@@ -2828,7 +2872,7 @@ func (h *bountyHandler) CreateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(createdStake)
 }
@@ -2850,7 +2894,7 @@ func (h *bountyHandler) GetAllBountyStakes(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -2875,7 +2919,7 @@ func (h *bountyHandler) GetBountyStakesByBountyID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid bounty ID"})
 		return
 	}
-	
+
 	stakes, err := h.db.GetBountyStakesByBountyID(bountyID)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stakes by bounty ID: %v", err)
@@ -2883,7 +2927,7 @@ func (h *bountyHandler) GetBountyStakesByBountyID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -2909,7 +2953,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	stake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stake by ID: %v", err)
@@ -2917,7 +2961,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stake)
 }
@@ -2934,7 +2978,7 @@ func (h *bountyHandler) GetBountyStakeByID(w http.ResponseWriter, r *http.Reques
 //	@Router			/gobounties/stake/hunter/{hunterPubKey} [get]
 func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *http.Request) {
 	hunterPubKey := chi.URLParam(r, "hunterPubKey")
-	
+
 	stakes, err := h.db.GetBountyStakesByHunterPubKey(hunterPubKey)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to get stakes by hunter pubkey: %v", err)
@@ -2942,7 +2986,7 @@ func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stakes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(stakes)
 }
@@ -2966,14 +3010,14 @@ func (h *bountyHandler) GetBountyStakesByHunterPubKey(w http.ResponseWriter, r *
 func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -2982,7 +3026,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	existingStake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] stake not found: %v", err)
@@ -2990,7 +3034,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingStake.BountyID)
 	if existingStake.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake] unauthorized update attempt")
@@ -2998,7 +3042,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to update this stake"})
 		return
 	}
-	
+
 	var updates map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
 		logger.Log.Error("[bounty_stake] invalid request body: %v", err)
@@ -3006,7 +3050,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	updatedStake, err := h.db.UpdateBountyStake(id, updates)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to update stake: %v", err)
@@ -3014,7 +3058,7 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(updatedStake)
 }
@@ -3036,14 +3080,14 @@ func (h *bountyHandler) UpdateBountyStake(w http.ResponseWriter, r *http.Request
 func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3052,7 +3096,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid stake ID"})
 		return
 	}
-	
+
 	existingStake, err := h.db.GetBountyStakeByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] stake not found: %v", err)
@@ -3060,7 +3104,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingStake.BountyID)
 	if existingStake.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake] unauthorized delete attempt")
@@ -3068,7 +3112,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to delete this stake"})
 		return
 	}
-	
+
 	err = h.db.DeleteBountyStake(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake] failed to delete stake: %v", err)
@@ -3076,7 +3120,7 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"message": "Stake deleted successfully"})
 }
@@ -3098,14 +3142,14 @@ func (h *bountyHandler) DeleteBountyStake(w http.ResponseWriter, r *http.Request
 func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	var process db.BountyStakeProcess
 	if err := json.NewDecoder(r.Body).Decode(&process); err != nil {
 		logger.Log.Error("[bounty_stake_process] invalid request body: %v", err)
@@ -3113,11 +3157,11 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	process.HunterPubKey = pubKeyFromAuth
-	
+
 	process.Status = db.StakeProcessStatusNew
-	
+
 	createdProcess, err := h.db.CreateBountyStakeProcess(&process)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to create stake process: %v", err)
@@ -3125,7 +3169,7 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(createdProcess)
 }
@@ -3144,14 +3188,14 @@ func (h *bountyHandler) CreateBountyStakeProcess(w http.ResponseWriter, r *http.
 func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	processes, err := h.db.GetAllBountyStakeProcesses()
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to get stake processes: %v", err)
@@ -3159,7 +3203,7 @@ func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *htt
 		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to retrieve stake processes"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(processes)
 }
@@ -3181,14 +3225,14 @@ func (h *bountyHandler) GetAllBountyStakeProcesses(w http.ResponseWriter, r *htt
 func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3197,7 +3241,7 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	process, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to get process by ID: %v", err)
@@ -3205,7 +3249,7 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(process)
 }
@@ -3229,14 +3273,14 @@ func (h *bountyHandler) GetBountyStakeProcessByID(w http.ResponseWriter, r *http
 func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3245,7 +3289,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	existingProcess, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] process not found: %v", err)
@@ -3253,7 +3297,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingProcess.BountyID)
 	if existingProcess.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake_process] unauthorized update attempt")
@@ -3261,7 +3305,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to update this stake process"})
 		return
 	}
-	
+
 	var updates map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
 		logger.Log.Error("[bounty_stake_process] invalid request body: %v", err)
@@ -3269,7 +3313,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
 		return
 	}
-	
+
 	updatedProcess, err := h.db.UpdateBountyStakeProcess(id, updates)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to update process: %v", err)
@@ -3277,7 +3321,7 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(updatedProcess)
 }
@@ -3299,14 +3343,14 @@ func (h *bountyHandler) UpdateBountyStakeProcess(w http.ResponseWriter, r *http.
 func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
-	
+
 	if pubKeyFromAuth == "" {
 		logger.Log.Error("[bounty_stake_process] no pubkey from auth")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
 		return
 	}
-	
+
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
@@ -3315,7 +3359,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid process ID"})
 		return
 	}
-	
+
 	existingProcess, err := h.db.GetBountyStakeProcessByID(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] process not found: %v", err)
@@ -3323,7 +3367,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "Stake process not found"})
 		return
 	}
-	
+
 	bounty := h.db.GetBounty(existingProcess.BountyID)
 	if existingProcess.HunterPubKey != pubKeyFromAuth && bounty.OwnerID != pubKeyFromAuth {
 		logger.Log.Error("[bounty_stake_process] unauthorized delete attempt")
@@ -3331,7 +3375,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": "You are not authorized to delete this stake process"})
 		return
 	}
-	
+
 	err = h.db.DeleteBountyStakeProcess(id)
 	if err != nil {
 		logger.Log.Error("[bounty_stake_process] failed to delete process: %v", err)
@@ -3339,7 +3383,7 @@ func (h *bountyHandler) DeleteBountyStakeProcess(w http.ResponseWriter, r *http.
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"message": "Stake process deleted successfully"})
 }

--- a/handlers/bounty_test.go
+++ b/handlers/bounty_test.go
@@ -1165,7 +1165,7 @@ func TestGetBountyIndexById(t *testing.T) {
 			OwnerID:       bountyOwner.OwnerPubKey,
 			Show:          true,
 			Created:       now,
-			MaxStakers: 1,
+			MaxStakers:    1,
 		}
 
 		db.TestDB.CreateOrEditBounty(bounty)
@@ -1247,6 +1247,42 @@ func TestGetAllBounties(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.NotEmpty(t, returnedBounty)
+	})
+}
+
+func TestGetAllBountiesMyAssignedAuth(t *testing.T) {
+	mockHttpClient := mocks.NewHttpClient(t)
+
+	t.Run("requires auth for myAssigned filter", func(t *testing.T) {
+		mockDb := dbMocks.NewDatabase(t)
+		bHandler := NewBountyHandler(mockHttpClient, mockDb)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/gobounties/all?myAssigned=true", nil)
+
+		bHandler.GetAllBounties(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+		mockDb.AssertNotCalled(t, "GetAllBounties", mock.Anything)
+	})
+
+	t.Run("passes authenticated pubkey to database filter", func(t *testing.T) {
+		mockDb := dbMocks.NewDatabase(t)
+		bHandler := NewBountyHandler(mockHttpClient, mockDb)
+
+		mockDb.On("GetAllBounties", mock.MatchedBy(func(r *http.Request) bool {
+			pubKeyFromAuth, _ := r.Context().Value(auth.ContextKey).(string)
+			return pubKeyFromAuth == "user_pubkey" && r.URL.Query().Get("myAssigned") == "true"
+		})).Return([]db.NewBounty{}).Once()
+
+		rr := httptest.NewRecorder()
+		ctx := context.WithValue(context.Background(), auth.ContextKey, "user_pubkey")
+		req := httptest.NewRequest(http.MethodGet, "/gobounties/all?myAssigned=true", nil).WithContext(ctx)
+
+		bHandler.GetAllBounties(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		mockDb.AssertExpectations(t)
 	})
 }
 

--- a/mocks/Database.go
+++ b/mocks/Database.go
@@ -5696,6 +5696,62 @@ func (_c *Database_GetBountyByCreated_Call) RunAndReturn(run func(uint) (db.NewB
 	return _c
 }
 
+// GetBountyByUnlockCode provides a mock function with given fields: code
+func (_m *Database) GetBountyByUnlockCode(code string) (db.NewBounty, error) {
+	ret := _m.Called(code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBountyByUnlockCode")
+	}
+
+	var r0 db.NewBounty
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (db.NewBounty, error)); ok {
+		return rf(code)
+	}
+	if rf, ok := ret.Get(0).(func(string) db.NewBounty); ok {
+		r0 = rf(code)
+	} else {
+		r0 = ret.Get(0).(db.NewBounty)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(code)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Database_GetBountyByUnlockCode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBountyByUnlockCode'
+type Database_GetBountyByUnlockCode_Call struct {
+	*mock.Call
+}
+
+// GetBountyByUnlockCode is a helper method to define mock.On call
+//   - code string
+func (_e *Database_Expecter) GetBountyByUnlockCode(code interface{}) *Database_GetBountyByUnlockCode_Call {
+	return &Database_GetBountyByUnlockCode_Call{Call: _e.mock.On("GetBountyByUnlockCode", code)}
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) Run(run func(code string)) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) Return(_a0 db.NewBounty, _a1 error) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Database_GetBountyByUnlockCode_Call) RunAndReturn(run func(string) (db.NewBounty, error)) *Database_GetBountyByUnlockCode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBountyById provides a mock function with given fields: id
 func (_m *Database) GetBountyById(id string) ([]db.NewBounty, error) {
 	ret := _m.Called(id)
@@ -17486,7 +17542,6 @@ func (_c *Database_GetAllBountyStakes_Call) RunAndReturn(run func() ([]db.Bounty
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakesByBountyID(bountyID uint) ([]db.BountyStake, error) {
 	ret := _m.Called(bountyID)
 
@@ -17703,7 +17758,6 @@ func (_c *Database_UpdateBountyStake_Call) RunAndReturn(run func(uuid.UUID, map[
 	return _c
 }
 
-
 func (_m *Database) DeleteBountyStake(stakeID uuid.UUID) error {
 	ret := _m.Called(stakeID)
 
@@ -17746,7 +17800,6 @@ func (_c *Database_DeleteBountyStake_Call) RunAndReturn(run func(uuid.UUID) erro
 	return _c
 }
 
-
 func (_m *Database) AddChatStatus(status *db.ChatWorkflowStatus) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(status)
 
@@ -17778,7 +17831,6 @@ type Database_AddChatStatus_Call struct {
 	*mock.Call
 }
 
-
 func (_e *Database_Expecter) AddChatStatus(status interface{}) *Database_AddChatStatus_Call {
 	return &Database_AddChatStatus_Call{Call: _e.mock.On("AddChatStatus", status)}
 }
@@ -17799,7 +17851,6 @@ func (_c *Database_AddChatStatus_Call) RunAndReturn(run func(*db.ChatWorkflowSta
 	_c.Call.Return(run)
 	return _c
 }
-
 
 func (_m *Database) UpdateChatStatus(status *db.ChatWorkflowStatus) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(status)
@@ -17831,7 +17882,6 @@ func (_m *Database) UpdateChatStatus(status *db.ChatWorkflowStatus) (db.ChatWork
 type Database_UpdateChatStatus_Call struct {
 	*mock.Call
 }
-
 
 func (_e *Database_Expecter) UpdateChatStatus(status interface{}) *Database_UpdateChatStatus_Call {
 	return &Database_UpdateChatStatus_Call{Call: _e.mock.On("UpdateChatStatus", status)}
@@ -17908,7 +17958,6 @@ func (_c *Database_GetChatStatusByChatID_Call) RunAndReturn(run func(string) ([]
 	return _c
 }
 
-
 func (_m *Database) GetLatestChatStatusByChatID(chatID string) (db.ChatWorkflowStatus, error) {
 	ret := _m.Called(chatID)
 
@@ -17981,7 +18030,6 @@ func (_m *Database) DeleteChatStatus(_a0 uuid.UUID) error {
 type Database_DeleteChatStatus_Call struct {
 	*mock.Call
 }
-
 
 func (_e *Database_Expecter) DeleteChatStatus(_a0 interface{}) *Database_DeleteChatStatus_Call {
 	return &Database_DeleteChatStatus_Call{Call: _e.mock.On("DeleteChatStatus", _a0)}
@@ -18110,7 +18158,6 @@ func (_c *Database_CreateBountyStakeProcess_Call) RunAndReturn(run func(*db.Boun
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakeProcessByID(id uuid.UUID) (*db.BountyStakeProcess, error) {
 	ret := _m.Called(id)
 
@@ -18219,7 +18266,6 @@ func (_c *Database_GetBountyStakeProcessesByBountyID_Call) RunAndReturn(run func
 	return _c
 }
 
-
 func (_m *Database) GetBountyStakeProcessesByHunterPubKey(hunterPubKey string) ([]db.BountyStakeProcess, error) {
 	ret := _m.Called(hunterPubKey)
 
@@ -18327,7 +18373,6 @@ func (_c *Database_GetAllBountyStakeProcesses_Call) RunAndReturn(run func() ([]d
 	_c.Call.Return(run)
 	return _c
 }
-
 
 func (_m *Database) UpdateBountyStakeProcess(id uuid.UUID, updates map[string]interface{}) (*db.BountyStakeProcess, error) {
 	ret := _m.Called(id, updates)


### PR DESCRIPTION
## Summary
- adds `myAssigned=true` support to `/gobounties/all`
- requires an authenticated pubkey only when the assigned-to-me filter is requested, preserving the public bounty list behavior otherwise
- filters returned bounties to the authenticated user assignee and covers the handler auth gate with unit tests
- refreshes the generated database mock so the handler package compiles against the current database interface

Fixes stakwork/sphinx-tribes#2436.

## Validation
- `go test ./handlers -run TestGetAllBountiesMyAssignedAuth -count=1`
- `go test ./handlers -run '^$' -count=1`
- `go test ./db -run '^$' -count=1`
- `git diff --check`