### PR TITLE
Add feature phase tickets route

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2771,6 +2771,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/features/{feature_uuid}/phase/{phase_uuid}/tickets": {
+            "get": {
+                "security": [
+                    {
+                        "PubKeyContextAuth": []
+                    }
+                ],
+                "description": "Get tickets of a feature by its UUID and phase UUID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feature - Phases"
+                ],
+                "summary": "Get Tickets by Feature and Phase UUID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Feature UUID",
+                        "name": "feature_uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Phase UUID",
+                        "name": "phase_uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/db.Tickets"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/features/{feature_uuid}/phase/{phase_uuid}/bounty/count": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2765,6 +2765,53 @@
                 }
             }
         },
+        "/features/{feature_uuid}/phase/{phase_uuid}/tickets": {
+            "get": {
+                "security": [
+                    {
+                        "PubKeyContextAuth": []
+                    }
+                ],
+                "description": "Get tickets of a feature by its UUID and phase UUID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feature - Phases"
+                ],
+                "summary": "Get Tickets by Feature and Phase UUID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Feature UUID",
+                        "name": "feature_uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Phase UUID",
+                        "name": "phase_uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/db.Tickets"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/features/{feature_uuid}/phase/{phase_uuid}/bounty/count": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4018,6 +4018,36 @@ paths:
       summary: Get Bounties by Feature and Phase UUID
       tags:
       - Feature - Phases
+  /features/{feature_uuid}/phase/{phase_uuid}/tickets:
+    get:
+      consumes:
+      - application/json
+      description: Get tickets of a feature by its UUID and phase UUID
+      parameters:
+      - description: Feature UUID
+        in: path
+        name: feature_uuid
+        required: true
+        type: string
+      - description: Phase UUID
+        in: path
+        name: phase_uuid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/db.Tickets'
+            type: array
+      security:
+      - PubKeyContextAuth: []
+      summary: Get Tickets by Feature and Phase UUID
+      tags:
+      - Feature - Phases
   /features/{feature_uuid}/phase/{phase_uuid}/bounty/count:
     get:
       consumes:

--- a/handlers/features.go
+++ b/handlers/features.go
@@ -34,8 +34,8 @@ type PostData struct {
 }
 
 type FeatureCallRequest struct {
-    WorkspaceID string `json:"workspace_id"`
-    URL         string `json:"url"`
+	WorkspaceID string `json:"workspace_id"`
+	URL         string `json:"url"`
 }
 
 type FeatureBriefRequest struct {
@@ -686,6 +686,63 @@ func (oh *featureHandler) GetBountiesByFeatureAndPhaseUuid(w http.ResponseWriter
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(bountyResponses)
+}
+
+// GetTicketsByFeatureAndPhaseUuid godoc
+//
+//	@Summary		Get Tickets by Feature and Phase UUID
+//	@Description	Get tickets of a feature by its UUID and phase UUID
+//	@Tags			Feature - Phases
+//	@Accept			json
+//	@Produce		json
+//	@Security		PubKeyContextAuth
+//	@Param			feature_uuid	path	string	true	"Feature UUID"
+//	@Param			phase_uuid		path	string	true	"Phase UUID"
+//	@Success		200				{array}	db.Tickets
+//	@Router			/features/{feature_uuid}/phase/{phase_uuid}/tickets [get]
+func (oh *featureHandler) GetTicketsByFeatureAndPhaseUuid(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	pubKeyFromAuth, _ := ctx.Value(auth.ContextKey).(string)
+	if pubKeyFromAuth == "" {
+		logger.Log.Info("no pubkey from auth")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	featureUuid := chi.URLParam(r, "feature_uuid")
+	phaseUuid := chi.URLParam(r, "phase_uuid")
+	if featureUuid == "" {
+		http.Error(w, "Missing feature uuid", http.StatusBadRequest)
+		return
+	}
+	if phaseUuid == "" {
+		http.Error(w, "Missing phase uuid", http.StatusBadRequest)
+		return
+	}
+
+	feature := oh.db.GetFeatureByUuid(featureUuid)
+	if feature.Uuid == "" {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "feature not found"})
+		return
+	}
+
+	_, err := oh.db.GetFeaturePhaseByUuid(featureUuid, phaseUuid)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Phase not found"})
+		return
+	}
+
+	tickets, err := oh.db.GetTicketsByPhaseUUID(featureUuid, phaseUuid)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(tickets)
 }
 
 // GetBountiesCountByFeatureAndPhaseUuid godoc

--- a/routes/features.go
+++ b/routes/features.go
@@ -41,6 +41,7 @@ func FeatureRoutes() chi.Router {
 		r.Delete("/{feature_uuid}/story/{story_uuid}", featureHandlers.DeleteStory)
 		r.Get("/{feature_uuid}/phase/{phase_uuid}/bounty", featureHandlers.GetBountiesByFeatureAndPhaseUuid)
 		r.Get("/{feature_uuid}/phase/{phase_uuid}/bounty/count", featureHandlers.GetBountiesCountByFeatureAndPhaseUuid)
+		r.Get("/{feature_uuid}/phase/{phase_uuid}/tickets", featureHandlers.GetTicketsByFeatureAndPhaseUuid)
 		r.Get("/{feature_uuid}/quick-bounties", featureHandlers.GetQuickBounties)
 		r.Get("/{feature_uuid}/quick-tickets", featureHandlers.GetQuickTickets)
 		r.Post("/call", featureHandlers.CreateOrUpdateFeatureCall)

--- a/routes/features_test.go
+++ b/routes/features_test.go
@@ -19,6 +19,10 @@ func FeatureMockHandler(t *testing.T, expectedStatus int) http.HandlerFunc {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
+		if r.Method == http.MethodGet && r.URL.Path == "/1234/phase/5678/tickets" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		if r.Method == http.MethodPost && r.URL.Path == "/stories" {
 			w.WriteHeader(http.StatusOK)
 			return
@@ -59,6 +63,7 @@ func TestFeatureRoutes(t *testing.T) {
 	r.Get("/workspace/count/{uuid}", FeatureMockHandler(t, http.StatusOK))
 	r.Post("/phase", FeatureMockHandler(t, http.StatusOK))
 	r.Get("/{feature_uuid}/story", FeatureMockHandler(t, http.StatusOK))
+	r.Get("/{feature_uuid}/phase/{phase_uuid}/tickets", FeatureMockHandler(t, http.StatusOK))
 
 	testCases := []struct {
 		name           string
@@ -112,6 +117,12 @@ func TestFeatureRoutes(t *testing.T) {
 			name:           "Test GET /{feature_uuid}/story Route",
 			method:         http.MethodGet,
 			path:           "/1234/story",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "Test GET /{feature_uuid}/phase/{phase_uuid}/tickets Route",
+			method:         http.MethodGet,
+			path:           "/1234/phase/5678/tickets",
 			expectedStatus: http.StatusOK,
 		},
 	}


### PR DESCRIPTION
## Summary
- add `GET /features/{feature_uuid}/phase/{phase_uuid}/tickets`
- validate auth, feature existence, and phase existence before returning phase tickets
- update route coverage and generated Swagger docs for the new endpoint

Fixes #1982
Addresses #1983

## Validation
- `go test ./routes -run '^TestFeatureRoutes$' -count=1`
- `go test ./routes -run '^$' -count=1`
- `git diff --check`
- `Get-Content -Raw docs\swagger.json | ConvertFrom-Json | Out-Null`

## Known existing blocker
- `go test ./handlers -run '^$' -count=1` is still blocked by the existing stale mock issue: `mocks.Database` does not implement `db.Database` because it is missing `GetBountyByUnlockCode`.