### PR TITLE
Use handler database for person referral lookup

### DIFF
--- a/handlers/people.go
+++ b/handlers/people.go
@@ -89,7 +89,7 @@ func (ph *peopleHandler) CreatePerson(w http.ResponseWriter, r *http.Request) {
 
 		if referredBy != "" {
 			// get the referral and populate the pubkey
-			referral := db.DB.GetPersonByUuid(referredBy)
+			referral := ph.db.GetPersonByUuid(referredBy)
 			// if referral exists
 			if referral.ID != 0 {
 				person.ReferredBy = referral.ID

--- a/handlers/people_test.go
+++ b/handlers/people_test.go
@@ -152,6 +152,47 @@ func TestCreatePerson(t *testing.T) {
 		assert.EqualValues(t, person, fetchedUpdatedPerson)
 	})
 
+	t.Run("should create user with referred_by person id from referral uuid", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(pHandler.CreatePerson)
+
+		referrer := db.Person{
+			Uuid:         uuid.New().String(),
+			OwnerAlias:   "referrer",
+			UniqueName:   "referrer",
+			OwnerPubKey:  uuid.New().String(),
+			Tags:         pq.StringArray{},
+			Extras:       db.PropertyMap{},
+			GithubIssues: db.PropertyMap{},
+		}
+
+		createdReferrer, err := db.TestDB.CreateOrEditPerson(referrer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		referredPerson := db.Person{
+			OwnerAlias:   "referred-person",
+			OwnerPubKey:  uuid.New().String(),
+			Tags:         pq.StringArray{},
+			Extras:       db.PropertyMap{},
+			GithubIssues: db.PropertyMap{},
+		}
+		requestBody, _ := json.Marshal(referredPerson)
+		ctx := context.WithValue(context.Background(), auth.ContextKey, referredPerson.OwnerPubKey)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/?referred_by="+createdReferrer.Uuid, bytes.NewReader(requestBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler.ServeHTTP(rr, req)
+
+		fetchedCreatedPerson := db.TestDB.GetPersonByPubkey(referredPerson.OwnerPubKey)
+
+		assert.Equal(t, http.StatusOK, rr.Code, "invalid status received")
+		assert.Equal(t, createdReferrer.ID, fetchedCreatedPerson.ReferredBy)
+	})
+
 	t.Run("Should return a 200 status code when existing user hits the endpoint", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(pHandler.CreatePerson)


### PR DESCRIPTION
## Summary
- resolve `referred_by` UUIDs through the injected people handler database instead of the global database
- add CreatePerson coverage proving a referral UUID stores the referrer person ID on the new person

Addresses stakwork/sphinx-tribes#1484.

## Validation
- `go test ./routes -run '^TestPeopleRoutes$' -count=1`
- `git diff --check`

Attempted but currently blocked by existing stale mocks:
- `go test ./handlers -run '^TestCreatePerson$/should_create_user_with_referred_by_person_id_from_referral_uuid$' -count=1`
- `go test ./handlers -run '^$' -count=1`

Both handler commands fail before running this test because `mocks.Database` is missing `GetBountyByUnlockCode`, matching the existing repo-wide handler test compile blocker.