### PR TITLE
Use production Tribes image for frontend E2E

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -46,14 +46,22 @@ jobs:
         with:
           node-version: 20
 
-      - name: Build Tribes Image
-        run: pwd && ls && docker build -t sphinxlightning/sphinx-tribes:latest .
+      - name: Pull Production Tribes Image
+        run: |
+          docker pull sphinxlightning/sphinx-tribes:latest
+          docker image inspect sphinxlightning/sphinx-tribes:latest --format '{{.Id}} {{.Created}}'
 
 
 # change_v2_ports
       - name: Clone Stack
         run: |
           git clone --single-branch --branch change_v2_ports https://github.com/stakwork/sphinx-stack.git stack
+
+      - name: Use Production Tribes Image
+        run: |
+          grep -q 'sphinxlightning/sphinx-tribes:integrate_v2_payments3' ./stack/alts/v1v2.yml
+          sed -i 's|sphinxlightning/sphinx-tribes:integrate_v2_payments3|sphinxlightning/sphinx-tribes:latest|' ./stack/alts/v1v2.yml
+          grep -n 'sphinxlightning/sphinx-tribes:latest' ./stack/alts/v1v2.yml
 
       - name: Clone Sphinx Tribes Frontend
         run: |


### PR DESCRIPTION
## Summary
- Replace the frontend E2E workflow's local backend Docker build with a pull of `sphinxlightning/sphinx-tribes:latest`.
- Rewrite the cloned stack's pinned Tribes image tag to `latest` before `docker compose up`, so the E2E stack actually runs against the production image.
- Inspect the pulled image in CI so the run logs show which production image was used.

Fixes stakwork/sphinx-tribes#1573.

## Validation
- `git diff --check`
- `rg -n "docker build -t sphinxlightning/sphinx-tribes|docker pull sphinxlightning/sphinx-tribes:latest|Use Production Tribes Image|integrate_v2_payments3|sphinxlightning/sphinx-tribes:latest" .github\workflows\frontend-e2e.yml`
- `npx --yes js-yaml .github/workflows/frontend-e2e.yml`